### PR TITLE
win: make writev emulation work for non-socket fds

### DIFF
--- a/src/win/win.h
+++ b/src/win/win.h
@@ -5,6 +5,8 @@
 #include <ws2tcpip.h>
 #include <iphlpapi.h>
 #include <ws2def.h>
+#include <io.h>
+#include <limits.h>
 #include "log.h"
 
 typedef intptr_t fd_t;
@@ -17,19 +19,48 @@ struct iovec {
 
 static inline ssize_t writev(fd_t fd, const struct iovec *iov, int iovcnt)
 {
+	int so_type = 0;
+	int so_type_len = (int)sizeof(so_type);
 	DWORD sent = 0;
-	/* WSABUF has {ULONG len, CHAR *buf} — same layout as iovec on
-	 * little-endian Windows if we repack. Build a small stack array. */
-	WSABUF wsa[64];
-	int i, n = iovcnt < 64 ? iovcnt : 64;
-	for (i = 0; i < n; i++) {
-		wsa[i].len = (ULONG)iov[i].iov_len;
-		wsa[i].buf = (CHAR *)iov[i].iov_base;
+
+	/* Socket path: use WSASend (supports scatter/gather efficiently). */
+	if (getsockopt((SOCKET)fd, SOL_SOCKET, SO_TYPE, (char *)&so_type,
+		       &so_type_len) == 0) {
+		/* WSABUF has {ULONG len, CHAR *buf}. Build a small stack array. */
+		WSABUF wsa[64];
+		int i, n = iovcnt < 64 ? iovcnt : 64;
+		for (i = 0; i < n; i++) {
+			wsa[i].len = (ULONG)iov[i].iov_len;
+			wsa[i].buf = (CHAR *)iov[i].iov_base;
+		}
+		if (WSASend((SOCKET)fd, wsa, n, &sent, 0, NULL, NULL) != 0)
+			return -1;
+		return (ssize_t)sent;
 	}
-	int ret = WSASend((SOCKET)fd, wsa, n, &sent, 0, NULL, NULL);
-	if (ret != 0)
-		return -1;
-	return (ssize_t)sent;
+
+	/* Non-socket path: emulate writev with repeated _write for file fds. */
+	size_t total = 0;
+	int i;
+	for (i = 0; i < iovcnt; i++) {
+		const char *p = (const char *)iov[i].iov_base;
+		size_t remain = iov[i].iov_len;
+		while (remain > 0) {
+			/* _write() takes unsigned int length, split big buffers. */
+			const unsigned max_write_chunk = (unsigned)INT_MAX;
+			unsigned chunk = remain > max_write_chunk ?
+						 max_write_chunk :
+						 (unsigned)remain;
+			int n = _write((int)fd, p, chunk);
+			if (n < 0)
+				return total > 0 ? (ssize_t)total : -1;
+			if (n == 0)
+				return (ssize_t)total;
+			total += (size_t)n;
+			p += n;
+			remain -= (size_t)n;
+		}
+	}
+	return (ssize_t)total;
 }
 
 #define open_fd_count() 0


### PR DESCRIPTION
### Motivation
- `writev` on Windows was always mapped to `WSASend`, which only works for sockets and fails for ordinary file descriptors like `STDOUT_FILENO` under MinGW/CRT. The goal is correctness on Windows even if it costs some performance.

### Description
- Update `src/win/win.h` to detect whether `fd` is a socket by calling `getsockopt(..., SO_TYPE)` and keep the `WSASend` path for socket fds. 
- Add a non-socket fallback that emulates `writev` by repeatedly calling `_write` over each `iovec`, handling large chunks and partial writes and returning the total bytes written or `-1` on error. 
- Add `#include <io.h>` to access `_write` and ensure file-descriptor path compiles on Windows.

### Testing
- No automated tests were executed for this change because it is Windows-specific and could not be validated in the current Linux environment/CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8928f0950832dbb046cfde450bc71)