### PR TITLE
http: extract url module, add redirect support, and fix host header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,24 @@
 ## Unreleased
 
+### Added
+- `net.http.url` module with URL parsing (`parse`), resolution (`resolve`), reconstruction (`build`), query escaping/unescaping (`queryescape`, `queryunescape`), and path escaping/unescaping (`pathescape`, `pathunescape`).
+- HTTP client redirect support (301/302/303/307/308) with loop detection and max redirect limit.
+- `client.close()` to gracefully shut down pooled connections.
+- Tests for host header deduplication and user header preservation in both h1 and h2.
+
 ### Changed
+- URL parsing and encoding extracted from `net.http.helper` into `net.http.url`; `helper.parseurl`/`urlencode`/`urldecode` replaced by `url.parse`/`queryescape`/`pathunescape`.
+- h1 and h2 now inject the Host/`:authority` header from the URL authority instead of the user-supplied header table; the user's header table is never modified.
+- h1 `request()` accepts an optional `timeout` parameter for `Expect: 100-continue` wait.
+- h1 client `read`/`readall` use a single deadline timer instead of passing timeout to each internal `conn:read`, eliminating timeout amplification across chunked/content-length reads.
 - `cluster.connect` no longer caches peers by address; connecting to the same address now creates independent connections (for load balancing scenarios). It is now lazy (the TCP connection is established on the first `call`/`send`) and its return signature changed from `peer?, err?` to `peer` — errors are surfaced at call time instead.
 - `accept` callback signature changed from `function(peer, addr)` to `function(peer)`; client address available via `peer.remoteaddr`.
 - Peer objects now have `remoteaddr` field (set for both incoming and outgoing connections); `addr` field is only set for outgoing connections.
+
+### Fixed
+- Host header no longer duplicated when both the URL and user header table contain a host value.
+- Chunk size parsing handles missing hex before `tonumber` in h1.
+- Reset eof flag after 100-continue response in h1.
 
 ## v0.7.1 (Apr 10, 2026)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,6 +196,7 @@ Always prefer these over web search or training-data recall — they match the c
 | `silly.net.tls` | `docs/src/en/reference/net/tls.md` |
 | `silly.net.udp` | `docs/src/en/reference/net/udp.md` |
 | `silly.net.http` | `docs/src/en/reference/net/http.md` |
+| `silly.net.http.url` | `docs/src/en/reference/net/url.md` |
 | `silly.net.websocket` | `docs/src/en/reference/net/websocket.md` |
 | `silly.net.grpc` | `docs/src/en/reference/net/grpc.md` |
 | `silly.net.cluster` | `docs/src/en/reference/net/cluster.md` |
@@ -241,6 +242,10 @@ Nothing else. Every other module — `silly.net.http` (including `http.h1`, `htt
 **Why this matters**: the moment downstream code branches on `errno.XXX` from a non-transport module, that module loses the freedom to change its error wording — and the wide `silly.errno` table (which surfaces every libc errno on the platform) becomes load-bearing in places it was never meant to be.
 
 **Peer close**: a normal peer close reported through transport `close` callbacks is `errno.EOF`, not `nil`.
+
+## Changelog
+
+When modifying non-test code, update `CHANGELOG.md` under `## Unreleased` in the appropriate section (`Added`/`Changed`/`Fixed`). Do not edit past version entries.
 
 ## Code Patterns
 

--- a/docs/src/en/reference/net/README.md
+++ b/docs/src/en/reference/net/README.md
@@ -26,3 +26,4 @@ The `silly.net` module provides network-related functionality, including impleme
 
 ### Utilities
 - [addr](addr.md) - Address parsing and joining helpers
+- [url](url.md) - URL parsing, resolution, and encoding

--- a/docs/src/en/reference/net/http.md
+++ b/docs/src/en/reference/net/http.md
@@ -24,9 +24,10 @@ local http = require "silly.net.http"
 ### Protocol Support
 
 - **HTTP/1.1**: Supports persistent connections, chunked transfer, pipelining
-  - Note: HTTP/1.1 currently does not support client connection pooling; each request creates a new connection
 - **HTTP/2**: Supports multiplexing, server push, header compression
 - **Automatic Protocol Negotiation**: Automatically selects protocol version via ALPN
+- **Client Connection Pooling**: Both HTTP/1.1 and HTTP/2 connections are pooled and reused automatically
+- **Redirect Support**: `http.get` and `http.post` follow redirects (301/302/303/307/308) automatically with loop detection
 
 ### Stream Object
 
@@ -259,7 +260,7 @@ end)
 
 ### http.get(url [, headers])
 
-Sends an HTTP GET request (asynchronous).
+Sends an HTTP GET request with automatic redirect following (asynchronous).
 
 - **Parameters**:
   - `url`: `string` - Request URL (complete URL including protocol and host)
@@ -292,7 +293,7 @@ end)
 
 ### http.post(url [, headers [, body]])
 
-Sends an HTTP POST request (asynchronous).
+Sends an HTTP POST request with automatic redirect following (asynchronous).
 
 - **Parameters**:
   - `url`: `string` - Request URL
@@ -333,20 +334,18 @@ task.fork(function()
 end)
 ```
 
-### http.request(method, url [, headers [, close [, alpn_protos]]])
+### http.request(method, url [, headers])
 
-Sends a custom HTTP request (asynchronous).
+Sends a custom HTTP request and returns a raw stream (no redirect handling).
 
 - **Parameters**:
   - `method`: `string` - HTTP method (GET, POST, PUT, DELETE, etc.)
   - `url`: `string` - Request URL
   - `headers`: `table|nil` (optional) - Request headers table
-  - `close`: `boolean|nil` (optional) - Whether to immediately close the connection
-  - `alpn_protos`: `string[]|nil` (optional) - ALPN protocol list
 - **Returns**:
   - Success: `stream` - HTTP stream object
   - Failure: `nil, string` - nil and error message
-- **Note**: The returned stream needs to be manually closed by calling `close()`
+- **Note**: The returned stream needs to be manually closed by calling `close()`. Unlike `http.get`/`http.post`, this function does **not** follow redirects.
 - **Example**:
 
 ```lua validate
@@ -361,9 +360,7 @@ task.fork(function()
         {
             ["content-type"] = "text/plain",
             ["content-length"] = #"Updated data",
-        },
-        false,
-        {"http/1.1", "h2"}
+        }
     )
 
     if not stream then
@@ -371,18 +368,87 @@ task.fork(function()
         return
     end
 
-    if stream.version == "HTTP/2" then
-        stream:closewrite("Updated data")
-    else
-        stream:write("Updated data")
-    end
-
-    local status, header = stream:readheader()
-    if status then
-        print("Status:", status)
+    stream:closewrite("Updated data")
+    local ok, wait_err = stream:waitresponse()
+    if ok then
+        print("Status:", stream.status)
     end
 end)
 ```
+
+---
+
+## Connection Pool Client API
+
+The `http.newclient` function creates a dedicated HTTP client with connection pooling. This is useful for making multiple requests to the same host.
+
+### http.newclient([opts])
+
+Creates a new HTTP client with connection pooling.
+
+- **Parameters**:
+  - `opts`: `table|nil` (optional) - Client configuration
+    - `max_idle_per_host`: `integer?` - Maximum idle connections per host (default: 10)
+    - `idle_timeout`: `integer?` - Idle connection timeout in ms (default: 30000)
+    - `alpnprotos`: `string[]?` - ALPN protocols (default: `{"http/1.1", "h2"}`)
+- **Returns**: `client` - HTTP client object
+- **Example**:
+
+```lua validate
+local http = require "silly.net.http"
+
+local client = http.newclient({
+    max_idle_per_host = 5,
+    idle_timeout = 10000,
+})
+```
+
+### client:get(url [, headers])
+
+Sends a GET request with automatic redirect following (301/302/303/307/308).
+
+- **Parameters**:
+  - `url`: `string` - Request URL
+  - `headers`: `table|nil` (optional) - Request headers table
+- **Returns**:
+  - Success: `table` - Response object with `status`, `header`, `body`
+  - Failure: `nil, string` - nil and error message
+- **Redirect behavior**:
+  - 301/302/303: Method changes to GET, body is dropped
+  - 307/308: Method and body are preserved
+  - Maximum 10 redirects; loops are detected and reported as errors
+  - Gzip responses are automatically decompressed
+
+### client:post(url [, headers [, body]])
+
+Sends a POST request with automatic redirect following (301/302/303/307/308).
+
+- **Parameters**:
+  - `url`: `string` - Request URL
+  - `headers`: `table|nil` (optional) - Request headers table
+  - `body`: `string|nil` (optional) - Request body content
+- **Returns**: Same as `client:get`
+- **Redirect behavior**: Same as `client:get`
+- **Note**: If `body` is provided, the `content-length` header is automatically set
+
+### client:request(method, url [, headers])
+
+Sends a request without redirect handling. Returns a raw stream for full control.
+
+- **Parameters**:
+  - `method`: `string` - HTTP method
+  - `url`: `string` - Request URL
+  - `headers`: `table|nil` (optional) - Request headers table
+- **Returns**:
+  - Success: `stream` - HTTP stream object
+  - Failure: `nil, string` - nil and error message
+
+### client:close()
+
+Gracefully closes all pooled connections.
+
+- **Parameters**: None
+- **Returns**: None
 
 ---
 

--- a/docs/src/en/reference/net/url.md
+++ b/docs/src/en/reference/net/url.md
@@ -1,0 +1,152 @@
+---
+title: silly.net.http.url
+icon: link
+category:
+  - API Reference
+tag:
+  - Network
+  - HTTP
+  - URL
+---
+
+# silly.net.http.url
+
+The `silly.net.http.url` module provides URL parsing, resolution, and percent-encoding/decoding utilities for HTTP clients.
+
+## Module Import
+
+```lua validate
+local url = require "silly.net.http.url"
+```
+
+## url.parse(url)
+
+Parses a URL into a structured object.
+
+- **Parameters**:
+  - `url`: `string` - URL string (must include scheme, e.g. `"http://..."`)
+- **Returns**:
+  - Success: `table` with fields:
+    - `scheme`: `string` - URL scheme (`"http"`, `"https"`, `"ws"`, `"wss"`)
+    - `host`: `string` - Hostname (no brackets for IPv6, no port)
+    - `port`: `string` - Port as string (defaults: 80 for http/ws, 443 for https/wss)
+    - `authority`: `string` - `"host"` or `"host:port"` (omits port when it matches the scheme default)
+    - `path`: `string` - Request target (path + query + fragment; defaults to `"/"`)
+  - Failure: `nil, string`
+- **Example**:
+
+```lua validate
+local url = require "silly.net.http.url"
+
+local u, err = url.parse("http://example.com:8080/api?key=value")
+-- u.scheme     == "http"
+-- u.host       == "example.com"
+-- u.port       == "8080"
+-- u.authority  == "example.com:8080"
+-- u.path       == "/api?key=value"
+```
+
+## url.resolve(base_url, ref)
+
+Resolves a reference URL against a base URL (RFC 3986 Section 5).
+
+- **Parameters**:
+  - `base_url`: `string` - Base URL
+  - `ref`: `string` - Reference URL (absolute, protocol-relative, root-relative, path-relative, query-only, or fragment-only)
+- **Returns**: Same as `url.parse`
+- **Example**:
+
+```lua validate
+local url = require "silly.net.http.url"
+
+-- Absolute reference overrides base
+local u = url.resolve("http://example.com/path", "http://other.com/new")
+
+-- Path-relative: replaces last segment
+u = url.resolve("http://example.com/a/b", "c")
+-- u.path == "/a/c"
+
+-- Root-relative
+u = url.resolve("http://example.com/a/b", "/c/d")
+-- u.path == "/c/d"
+```
+
+## url.build(u)
+
+Reconstructs a full URL string from a parsed result.
+
+- **Parameters**:
+  - `u`: `table` - Parsed URL object (from `url.parse` or `url.resolve`)
+- **Returns**: `string`
+- **Example**:
+
+```lua validate
+local url = require "silly.net.http.url"
+
+local u = url.parse("http://example.com/path")
+local s = url.build(u)  -- "http://example.com/path"
+```
+
+## url.parsequery(query)
+
+Parses a query string into a key-value table. Duplicate keys use last-value-wins semantics.
+
+- **Parameters**:
+  - `query`: `string` - Query string (without the leading `?`)
+- **Returns**: `table<string, string>`
+- **Example**:
+
+```lua validate
+local url = require "silly.net.http.url"
+
+local q = url.parsequery("name=Alice&age=30")
+-- q["name"] == "Alice"
+-- q["age"]  == "30"
+```
+
+## url.queryescape(val)
+
+Encodes a string or table for use in URL query strings (`application/x-www-form-urlencoded`). Spaces become `+`.
+
+- **Parameters**:
+  - `val`: `string|table<string, string>` - String to encode, or table of key-value pairs
+- **Returns**: `string`
+- **Example**:
+
+```lua validate
+local url = require "silly.net.http.url"
+
+local s = url.queryescape("hello world")    -- "hello+world"
+local t = url.queryescape({a = "b&c"})      -- "a=b%26c"
+```
+
+## url.queryunescape(s)
+
+Decodes a query string value. Converts `+` to space and decodes `%XX` sequences.
+
+- **Parameters**:
+  - `s`: `string`
+- **Returns**: `string`
+
+## url.pathescape(val)
+
+Percent-encodes a string for use in URL path segments (RFC 3986).
+
+- **Parameters**:
+  - `val`: `string`
+- **Returns**: `string`
+
+## url.pathunescape(s)
+
+Decodes `%XX` sequences in a path string (RFC 3986). Does not convert `+` to space.
+
+- **Parameters**:
+  - `s`: `string`
+- **Returns**: `string`
+
+---
+
+## See Also
+
+- [silly.net.http](./http.md) - HTTP server and client
+- [silly.net.addr](./addr.md) - Address parsing helpers

--- a/luaclib-src/laddr.c
+++ b/luaclib-src/laddr.c
@@ -98,26 +98,23 @@ static int ljoin(lua_State *L)
 	size_t hostlen = 0;
 	size_t portlen = 0;
 	const char *host = luaL_optlstring(L, 1, NULL, &hostlen);
-	const char *port = luaL_checklstring(L, 2, &portlen);
+	const char *port = luaL_optlstring(L, 2, NULL, &portlen);
 
 	luaL_buffinit(L, &b);
-	if (host == NULL || hostlen == 0) {
+	if (hostlen > 0) {
+		if (host[0] != '[' && memchr(host, ':', hostlen) != NULL) {
+			luaL_addchar(&b, '[');
+			luaL_addlstring(&b, host, hostlen);
+			luaL_addchar(&b, ']');
+		} else {
+			luaL_addlstring(&b, host, hostlen);
+
+		}
+	}
+	if (portlen > 0) {
 		luaL_addchar(&b, ':');
 		luaL_addlstring(&b, port, portlen);
-		luaL_pushresult(&b);
-		return 1;
 	}
-	if (host[0] != '[' && memchr(host, ':', hostlen) != NULL) {
-		luaL_addchar(&b, '[');
-		luaL_addlstring(&b, host, hostlen);
-		luaL_addlstring(&b, "]:", 2);
-		luaL_addlstring(&b, port, portlen);
-		luaL_pushresult(&b);
-		return 1;
-	}
-	luaL_addlstring(&b, host, hostlen);
-	luaL_addchar(&b, ':');
-	luaL_addlstring(&b, port, portlen);
 	luaL_pushresult(&b);
 	return 1;
 }

--- a/lualib/silly/net/http/client.lua
+++ b/lualib/silly/net/http/client.lua
@@ -4,17 +4,47 @@ local tls = require "silly.net.tls"
 local dns = require "silly.net.dns"
 local h1 = require "silly.net.http.h1"
 local h2 = require "silly.net.http.h2"
-local helper = require "silly.net.http.helper"
+local url = require "silly.net.http.url"
 local gzip = require "silly.compress.gzip"
 local addr = require "silly.net.addr"
-local parseurl = helper.parseurl
+local urlparse = url.parse
+local urlresolve = url.resolve
+local urlbuild = url.build
 local join_addr = addr.join
-local assert = assert
 local pairs = pairs
 local setmetatable = setmetatable
 local format = string.format
 local tremove = table.remove
 local lower = string.lower
+
+global _
+
+local redirect_status = {
+	[301] = true,
+	[302] = true,
+	[303] = true,
+	[307] = true,
+	[308] = true,
+}
+
+local method_change_redirect = {
+	[301] = true,
+	[302] = true,
+	[303] = true,
+}
+
+-- Headers stripped on cross-origin redirects (matching Go's net/http behavior)
+local sensitive_headers = {
+	["authorization"] = true,
+	["www-authenticate"] = true,
+	["cookie"] = true,
+	["cookie2"] = true,
+	["proxy-authorization"] = true,
+	["proxy-authenticate"] = true,
+	["referer"] = true,
+}
+
+local MAX_FOLLOW_REDIRECTS = 10
 
 ---@class silly.net.http.client.pool.h1
 ---@field key string
@@ -29,6 +59,8 @@ local lower = string.lower
 ---@field client silly.net.http.client
 
 ---@class silly.net.http.client
+---@field package closed boolean
+---@field package timer integer?
 ---@field package max_idle_per_host integer
 ---@field package idle_timeout integer
 ---@field package alpnprotos silly.net.tls.alpn_proto[]
@@ -43,7 +75,6 @@ local h1using = {}
 local default_opts = {
 	max_idle_per_host = 10,
 	idle_timeout = 30000,
-	read_timeout = 5000,
 	alpnprotos = {"http/1.1", "h2"}
 }
 
@@ -53,36 +84,17 @@ local pool_mt = {__index = function(t, k)
 	return entries
 end}
 
----@param conn silly.net.tcp.conn|silly.net.tls.conn
----@param broken boolean
-local function releaseh1(conn, broken)
-	local entry = h1using[conn]
-	if not entry then
-		return
-	end
-	h1using[conn] = nil
-	if broken or not conn:isalive() then
-		conn:close()
-		return
-	end
-	local client = entry.client
-	local entries = client.h1pool[entry.key]
-	if #entries < client.max_idle_per_host then
-		entry.lastfree = time.now()
-		entries[#entries + 1] = entry
-	else
-		conn:close()
-	end
-end
-
 ---@param c silly.net.http.client
 local function check_alive_timer(c)
-	time.after(c.idle_timeout / 2, check_alive_timer, c)
+	if c.closed then
+		c.timer = nil
+		return
+	end
 	local now = time.now()
 	local idle_timeout = c.idle_timeout
 	local max_idle_per_host = c.max_idle_per_host
+	local alive = false
 
-	-- Check h1 pool
 	for k, entries in pairs(c.h1pool) do
 		local wi = 0
 		for i = 1, #entries do
@@ -99,10 +111,11 @@ local function check_alive_timer(c)
 		end
 		if wi == 0 then
 			c.h1pool[k] = nil
+		else
+			alive = true
 		end
 	end
 
-	-- Check h2 pool
 	for k, entries in pairs(c.h2pool) do
 		local wi = 0
 		local idle_count = 0
@@ -126,11 +139,48 @@ local function check_alive_timer(c)
 		end
 		if wi == 0 then
 			c.h2pool[k] = nil
+		else
+			alive = true
 		end
+	end
+
+	if alive then
+		c.timer = time.after(c.idle_timeout / 2, check_alive_timer, c)
+	else
+		c.timer = nil
 	end
 end
 
-local function find_conn(client, key, scheme)
+local function ensure_timer(c)
+	if not c.timer and not c.closed then
+		c.timer = time.after(c.idle_timeout / 2, check_alive_timer, c)
+	end
+end
+
+---@param conn silly.net.tcp.conn|silly.net.tls.conn
+---@param broken boolean
+local function releaseh1(conn, broken)
+	local entry = h1using[conn]
+	if not entry then
+		return
+	end
+	h1using[conn] = nil
+	if broken or not conn:isalive() then
+		conn:close()
+		return
+	end
+	local client = entry.client
+	local entries = client.h1pool[entry.key]
+	if #entries < client.max_idle_per_host then
+		entry.lastfree = time.now()
+		entries[#entries + 1] = entry
+		ensure_timer(client)
+	else
+		conn:close()
+	end
+end
+
+local function find_conn(client, key, scheme, authority)
 	-- find h2 stream first
 	local h2entries = client.h2pool[key]
 	for i = #h2entries, 1, -1 do
@@ -147,7 +197,7 @@ local function find_conn(client, key, scheme)
 		if entry.conn:isalive() then
 			h1using[entry.conn] = entry
 			tremove(h1entries, i)
-			return h1.newstream(scheme, entry.conn, releaseh1)
+			return h1.newstream(scheme, entry.conn, authority, releaseh1)
 		end
 	end
 	return nil
@@ -156,7 +206,6 @@ end
 ---@class silly.net.http.client.opts
 ---@field max_idle_per_host integer?  -- Maximum idle connections per host (default: 10)
 ---@field idle_timeout integer?       -- Idle connection timeout in ms (default: 30000)
----@field read_timeout integer?      -- Read timeout in ms (default: 5000)
 ---@field alpnprotos silly.net.tls.alpn_proto[]? -- ALPN protocols (default: {"http/1.1", "h2"})
 
 ---@param opts silly.net.http.client.opts?
@@ -164,51 +213,48 @@ end
 function M.new(opts)
 	---@type silly.net.http.client
 	local c = {
+		closed = false,
+		timer = nil,
 		max_idle_per_host = opts and opts.max_idle_per_host or default_opts.max_idle_per_host,
 		idle_timeout = opts and opts.idle_timeout or default_opts.idle_timeout,
-		readtimeout = opts and opts.read_timeout or default_opts.read_timeout,
 		alpnprotos = opts and opts.alpnprotos or default_opts.alpnprotos,
 		h1pool = setmetatable({}, pool_mt),
 		h2pool = setmetatable({}, pool_mt),
 	}
 	setmetatable(c, mt)
-	time.after(c.idle_timeout / 2, check_alive_timer, c)
 	return c
 end
 
 ---@param client silly.net.http.client
----@param scheme string
----@param host string
----@param port string
+---@param u silly.net.http.url.parts
 ---@return silly.net.http.h1.stream.client|silly.net.http.h2.stream|nil, string? error
-local function connect(client, scheme, host, port)
-	local key = format("%s:%s:%s", scheme, host, port)
-	local stream = find_conn(client, key, scheme)
+local function connect(client, u)
+	local key = format("%s:%s:%s", u.scheme, u.host, u.port)
+	local stream = find_conn(client, key, u.scheme, u.authority)
 	if stream then
 		return stream, nil
 	end
 
-	local ip, err = dns.lookup(host, dns.A)
+	local ip, err = dns.lookup(u.host, dns.A)
 	if not ip then
-		return nil, format("dns lookup %s failed: %s", host, err)
+		return nil, format("dns lookup %s failed: %s", u.host, err)
 	end
-	assert(ip, host)
-	local addr = join_addr(ip, port)
+	local a = join_addr(ip, u.port)
 	local conn
-	if scheme == "https" then
-		conn, err = tls.connect(addr, {
-			hostname = host,
+	if u.scheme == "https" then
+		conn, err = tls.connect(a, {
+			hostname = u.host,
 			alpnprotos = client.alpnprotos
 		})
 	else
-		conn, err = tcp.connect(addr)
+		conn, err = tcp.connect(a)
 	end
 	if not conn then
 		return nil, err
 	end
 	local alpnproto = conn.alpnproto
 	if alpnproto and alpnproto(conn) == "h2" then
-		local channel, err = h2.newchannel(scheme, conn)
+		local channel, err = h2.newchannel(u.scheme, conn, u.authority)
 		if not channel then
 			conn:close()
 			return nil, err
@@ -221,6 +267,7 @@ local function connect(client, scheme, host, port)
 		}
 		local entries = client.h2pool[key]
 		entries[#entries + 1] = entry
+		ensure_timer(client)
 		return channel:openstream(), nil
 	end
 	h1using[conn] = {
@@ -229,26 +276,24 @@ local function connect(client, scheme, host, port)
 		lastfree = 0,
 		client = client,
 	}
-	return h1.newstream(scheme, conn, releaseh1), nil
+	return h1.newstream(u.scheme, conn, u.authority, releaseh1), nil
 end
 
 ---@param client silly.net.http.client
 ---@param method string
----@param url string
+---@param u silly.net.http.url.parts
 ---@param header table<string, string|number>?
 ---@return silly.net.http.h2.stream|silly.net.http.h1.stream.client|nil, string?
-function M.request(client, method, url, header)
-	local scheme, host, port, path = parseurl(url)
-	if not scheme then
-		return nil, host
+local function request_url(client, method, u, header)
+	if client.closed then
+		return nil, "client is closed"
 	end
-	local stream, err = connect(client, scheme, host, port)
+	local stream, err = connect(client, u)
 	if not stream then
 		return nil, err
 	end
 	header = header or {}
-	header["host"] = host
-	local ok, err = stream:request(method, path, header)
+	local ok, err = stream:request(method, u.path, header)
 	if not ok then
 		stream:close()
 		return nil, err
@@ -257,67 +302,144 @@ function M.request(client, method, url, header)
 end
 
 ---@param client silly.net.http.client
-function M.get(client, url, header)
-	header = header or {}
-	-- RFC 7231: Automatically add Accept-Encoding if not set
-	if not header["accept-encoding"] then
-		header["accept-encoding"] = "gzip"
+---@param method string
+---@param url string
+---@param header table<string, string|number>?
+---@return silly.net.http.h2.stream|silly.net.http.h1.stream.client|nil, string?
+function M.request(client, method, url, header)
+	if client.closed then
+		return nil, "client is closed"
 	end
-	local stream<close>, err = client:request("GET", url, header)
-	if not stream then
+	local u, err = urlparse(url)
+	if not u then
 		return nil, err
 	end
-	stream:closewrite()
-	local body, err = stream:readall()
-	if not body then
+	return request_url(client, method, u, header)
+end
+
+---@param client silly.net.http.client
+---@param method string
+---@param url string
+---@param header table<string, string|number>
+---@param body string?
+---@return table? response, string? error
+local function do_with_redirects(client, method, url, header, body)
+	local seen = {}
+	local redirect_count = 0
+	local cur_method = method
+	local send_body = body
+	local u, err = urlparse(url)
+	if not u then
 		return nil, err
 	end
-	-- RFC 7231: Automatically decompress if Content-Encoding is gzip
-	local encoding = stream.header["content-encoding"]
-	if encoding and lower(encoding) == "gzip" then
-		body, err = gzip.decompress(body)
-		if not body then
+	local h = {}
+	for k, v in pairs(header) do
+		h[lower(k)] = v
+	end
+	local initial_scheme = u.scheme
+	local initial_authority = u.authority
+	local strip_sensitive = false
+	while redirect_count <= MAX_FOLLOW_REDIRECTS do
+		local url_key = urlbuild(u)
+		if seen[url_key] then
+			return nil, "redirect loop detected: " .. url_key
+		end
+		seen[url_key] = true
+		if not h["accept-encoding"] then
+			h["accept-encoding"] = "gzip"
+		end
+		if send_body then
+			h["content-length"] = #send_body
+		end
+		local stream<close>, err = request_url(client, cur_method, u, h)
+		if not stream then
 			return nil, err
 		end
+		stream:closewrite(send_body)
+		local resp_body, req_err = stream:readall()
+		if not resp_body then
+			return nil, req_err
+		end
+
+		local status = stream.status
+		if redirect_status[status] and stream.header["location"] then
+			local location = stream.header["location"]
+			u, err = urlresolve(url_key, location)
+			if not u then
+				return nil, err
+			end
+			if not strip_sensitive and (u.scheme ~= initial_scheme or u.authority ~= initial_authority) then
+				strip_sensitive = true
+			end
+			if strip_sensitive then
+				for k in pairs(h) do
+					if sensitive_headers[lower(k)] then
+						h[k] = nil
+					end
+				end
+			end
+			if method_change_redirect[status] then
+				cur_method = "GET"
+				send_body = nil
+				h["content-length"] = nil
+				h["content-type"] = nil
+			end
+			redirect_count = redirect_count + 1
+		else
+			local encoding = stream.header["content-encoding"]
+			if encoding and lower(encoding) == "gzip" then
+				resp_body, req_err = gzip.decompress(resp_body)
+				if not resp_body then
+					return nil, req_err
+				end
+			end
+			return {
+				status = stream.status,
+				header = stream.header,
+				body = resp_body,
+			}, nil
+		end
 	end
-	return {
-		status = stream.status,
-		header = stream.header,
-		body = body,
-	}, nil
+	return nil, "too many redirects"
+end
+
+---@param client silly.net.http.client
+function M.get(client, url, header)
+	return do_with_redirects(client, "GET", url, header or {}, nil)
 end
 
 ---@param client silly.net.http.client
 function M.post(client, url, header, body)
-	header = header or {}
-	if body then
-		header["content-length"] = #body
+	return do_with_redirects(client, "POST", url, header or {}, body)
+end
+
+---@param client silly.net.http.client
+function M.close(client)
+	if client.closed then
+		return
 	end
-	-- RFC 7231: Automatically add Accept-Encoding if not set
-	if not header["accept-encoding"] then
-		header["accept-encoding"] = "gzip"
+	client.closed = true
+	if client.timer then
+		time.cancel(client.timer)
+		client.timer = nil
 	end
-	local stream<close>, err = client:request("POST", url, header)
-	if not stream then
-		return nil, err
+	for k, entries in pairs(client.h1pool) do
+		for i = 1, #entries do
+			entries[i].conn:close()
+		end
+		client.h1pool[k] = nil
 	end
-	stream:closewrite(body)
-	local body, err = stream:readall()
-	if not body then
-		return nil, err
+	for k, entries in pairs(client.h2pool) do
+		for i = 1, #entries do
+			entries[i].channel:close()
+		end
+		client.h2pool[k] = nil
 	end
-	-- RFC 7231: Automatically decompress if Content-Encoding is gzip
-	local encoding = stream.header["content-encoding"]
-	if encoding and lower(encoding) == "gzip" then
-		body, err = gzip.decompress(body)
-		if not body then
-			return nil, err
+	for conn, entry in pairs(h1using) do
+		if entry.client == client then
+			conn:close()
+			h1using[conn] = nil
 		end
 	end
-	return {
-		status = stream.status,
-		header = stream.header,
-		body = body,
-	}, nil
 end
 return M

--- a/lualib/silly/net/http/h1.lua
+++ b/lualib/silly/net/http/h1.lua
@@ -1,9 +1,14 @@
 local silly = require "silly"
+local time = require "silly.time"
+local errno = require "silly.errno"
 local buffer = require "silly.adt.buffer"
 local helper = require "silly.net.http.helper"
 local logger = require "silly.logger"
 local statusname = require "silly.net.http.statusname"
+
 local type = type
+local pairs = pairs
+local ipairs = ipairs
 local assert = assert
 local tonumber = tonumber
 local lower = string.lower
@@ -11,8 +16,10 @@ local format = string.format
 local setmetatable = setmetatable
 local parsetarget = helper.parsetarget
 
-local errno = require "silly.errno"
 local EEOF<const> = errno.EOF
+local ETIMEDOUT<const> = errno.TIMEDOUT
+
+global _
 
 local M = {}
 
@@ -45,9 +52,11 @@ local M = {}
 
 --- @class silly.net.http.h1.stream.client : silly.net.http.h1.stream
 --- @field scheme string
+--- @field authority string
 --- @field status integer?
 --- @field package hasresponse boolean
 --- @field package release fun(conn: silly.net.tcp.conn|silly.net.tls.conn, broken: boolean)?
+--- @field package timedout boolean
 local h1c = {}
 
 --- @class silly.net.http.h1.stream.server : silly.net.http.h1.stream
@@ -71,6 +80,7 @@ local valid_methods = {
 	["OPTIONS"] = true,
 	["HEAD"] = true,
 	["CONNECT"] = true,
+	["PATCH"] = true,
 }
 
 -- RFC 9112: Methods whose request never has a body
@@ -90,19 +100,24 @@ local function bodyless_response(method, status)
 end
 
 local function compose_header(buf, header)
+	-- host is already written to sendbuf, suppress it from user header.
+	-- header keys are assumed to be pre-normalized to lowercase
+	-- (by client.lua do_with_redirects or the caller of M.request).
 	for k, v in pairs(header) do
-		if type(v) == "table" then
-			for _, vv in ipairs(v) do
+		if k ~= "host" then
+			if type(v) == "table" then
+				for _, vv in ipairs(v) do
+					buf[#buf + 1] = k
+					buf[#buf + 1] = ": "
+					buf[#buf + 1] = vv
+					buf[#buf + 1] = "\r\n"
+				end
+			else
 				buf[#buf + 1] = k
 				buf[#buf + 1] = ": "
-				buf[#buf + 1] = vv
+				buf[#buf + 1] = v
 				buf[#buf + 1] = "\r\n"
 			end
-		else
-			buf[#buf + 1] = k
-			buf[#buf + 1] = ": "
-			buf[#buf + 1] = v
-			buf[#buf + 1] = "\r\n"
 		end
 	end
 end
@@ -111,12 +126,12 @@ end
 ---@param header table<string, string|string[]>
 ---@param timeout integer? -- ms
 ---@return boolean, string?
-local function readheader(conn, header, timeout)
+local function read_header(conn, header, timeout)
 	local tmp, err = conn:read("\n", timeout)
 	if not tmp then
 		return false, err
 	end
-	while tmp ~= "\r\n" do
+	while tmp ~= "\r\n" and tmp ~= "\n" do
 		local k, v = tmp:match("^(%S+):%s*(.-)%s*$")
 		if not k then
 			return false, "Invalid header"
@@ -163,14 +178,13 @@ local function read_chunk(s, conn, timeout)
 	end
 	---@cast line string
 	local hex = line:match("^([0-9A-Fa-f]+)")
-	local sz = tonumber(hex, 16)
-	if not sz then
-		local err = "invalid chunk size"
-		return nil, err
+	if not hex then
+		return nil, "invalid chunk size"
 	end
+	local sz = tonumber(hex, 16)
 	if sz == 0 then
 		-- read trailer
-		local ok, err = readheader(conn, s.trailer, timeout)
+		local ok, err = read_header(conn, s.trailer, timeout)
 		if not ok then
 			return nil, err
 		end
@@ -310,7 +324,6 @@ local function readall(s, timeout)
 	end
 	if s.eof then
 		local dat = s.recvbuf:readall()
-
 		return dat, nil
 	end
 	local conn = s.conn
@@ -487,15 +500,23 @@ end
 -------------------------------------client
 
 ---@param s silly.net.http.h1.stream.client
----@param timeout integer?
-local function waitresponse(s, timeout)
+local function read_timeout(s)
+	s.timedout = true
 	local conn = s.conn
-	local first, err = conn:read("\n", timeout)
+	if conn then
+		conn:close()
+	end
+end
+
+---@param s silly.net.http.h1.stream.client
+local function waitresponse(s)
+	local conn = s.conn
+	local first, err = conn:read("\n")
 	if err then
 		return false, err
 	end
 	---@cast first string
-	local ok, err = readheader(conn, s.header, timeout)
+	local ok, err = read_header(conn, s.header)
 	if not ok then
 		return false, err
 	end
@@ -535,13 +556,17 @@ end
 ---@param method string
 ---@param path string
 ---@param header table<string, string>
+---@param timeout integer? -- ms, timeout for Expect: 100-continue
 ---@return boolean, string?
-function h1c.request(s, method, path, header)
+function h1c.request(s, method, path, header, timeout)
 	s.method = method
 	s.path = path
 	s.keepalive = header["connection"] ~= "close"
 	local buf = s.sendbuf
 	buf[#buf + 1] = format(request_line, method, path)
+	buf[#buf + 1] = "host: "
+	buf[#buf + 1] = s.authority
+	buf[#buf + 1] = "\r\n"
 	s.writeheader = header
 	s.allowbody = not bodyless_request[method]
 	local expect = header["expect"]
@@ -549,31 +574,44 @@ function h1c.request(s, method, path, header)
 	if expect100 then
 		flush_header(s, false)
 		flushwrite(s)
+		local timer
+		if timeout then
+			timer = time.after(timeout, read_timeout, s)
+		end
 		local ok, err = waitresponse(s)
+		if s.timedout then
+			s.err = ETIMEDOUT
+			return false, ETIMEDOUT
+		end
+		if timer then
+			time.cancel(timer)
+		end
 		if not ok then
 			s.err = err
 			return false, err
 		end
 		if s.status ~= 100 then
 			s.hasresponse = true
+			s.writeclosed = true
+		else
+			s.eof = false
 		end
 	end
 	return true, nil
 end
 
 ---@param s silly.net.http.h1.stream.client
----@param timeout integer? --ms
 ---@return boolean, string? error
-local function client_waitresponse(s, timeout)
+local function client_waitresponse(s)
 	if s.hasresponse then
 		return true, nil
 	end
-	s.hasresponse = true
 	local err = s.err
 	if err then
 		return false, err
 	end
-	local ok, err = waitresponse(s, timeout)
+	s.hasresponse = true
+	local ok, err = waitresponse(s)
 	if not ok then
 		s.err = err
 	end
@@ -590,11 +628,23 @@ function h1c.read(s, size, timeout)
 	if not s.writeclosed then
 		return nil, "Should closewrite first"
 	end
-	local ok, err = client_waitresponse(s, timeout)
-	if not ok then
-		return nil, err
+	local timer
+	if timeout then
+		timer = time.after(timeout, read_timeout, s)
 	end
-	return read(s, size, timeout)
+	local ok, err = client_waitresponse(s)
+	local data
+	if ok then
+		data, err = read(s, size)
+	end
+	if s.timedout then
+		s.err = ETIMEDOUT
+		return nil, ETIMEDOUT
+	end
+	if timer then
+		time.cancel(timer)
+	end
+	return data, err
 end
 
 ---@param s silly.net.http.h1.stream.client
@@ -604,11 +654,23 @@ function h1c.readall(s, timeout)
 	if not s.writeclosed then
 		return nil, "Should closewrite first"
 	end
-	local ok, err = client_waitresponse(s, timeout)
-	if not ok then
-		return nil, err
+	local timer
+	if timeout then
+		timer = time.after(timeout, read_timeout, s)
 	end
-	return readall(s, timeout)
+	local ok, err = client_waitresponse(s)
+	local data
+	if ok then
+		data, err = readall(s)
+	end
+	if s.timedout then
+		s.err = ETIMEDOUT
+		return nil, ETIMEDOUT
+	end
+	if timer then
+		time.cancel(timer)
+	end
+	return data, err
 end
 
 ---@param s silly.net.http.h1.stream.client
@@ -668,14 +730,17 @@ local h1c_mt = {
 
 ---@param scheme string
 ---@param conn silly.net.tcp.conn|silly.net.tls.conn
+---@param authority string
 ---@param release fun(conn: silly.net.tcp.conn|silly.net.tls.conn, broken: boolean)?
 ---@return silly.net.http.h1.stream.client
-function M.newstream(scheme, conn, release)
+function M.newstream(scheme, conn, authority, release)
 	local s = newstream(scheme, conn, "HTTP/1.1", "", "", {}, 0)
 	---@cast s silly.net.http.h1.stream.client
 	s.release = release
+	s.authority = authority
 	s.status = nil
 	s.hasresponse = false
+	s.timedout = false
 	setmetatable(s, h1c_mt)
 	return s
 end
@@ -737,6 +802,7 @@ local h1s_mt = {
 
 local err_400 = response_line[400] .. "\r\n"
 local err_405 = response_line[405] .. "\r\n"
+local err_505 = response_line[505] .. "\r\n"
 
 ---@param handler fun(s: silly.net.http.h1.stream.server)
 ---@param conn silly.net.tcp.conn|silly.net.tls.conn
@@ -750,7 +816,7 @@ function M.httpd(handler, conn, scheme)
 		end
 		---@cast first string
 		local header = {}
-		local ok, err = readheader(conn, header)
+		local ok, err = read_header(conn, header)
 		if not ok then
 			-- RFC 9112: Send 400 Bad Request for malformed headers
 			conn:write(err_400)
@@ -774,7 +840,7 @@ function M.httpd(handler, conn, scheme)
 		end
 		--request line
 		local method, target, ver =
-		    first:match("(%w+)%s+(.-)%s+HTTP/([%d|.]+)\r\n")
+		    first:match("([A-Za-z][A-Za-z0-9!#$%&'*+-.^_`|~]*)%s+(.-)%s+HTTP/([%d|.]+)\r\n")
 		if not valid_methods[method] then
 			-- RFC 9112: Send 405 Method Not Allowed for invalid method
 			conn:write(err_405)
@@ -786,7 +852,7 @@ function M.httpd(handler, conn, scheme)
 			break
 		end
 		if tonumber(ver) > 1.1 then
-			conn:write(err_405)
+			conn:write(err_505)
 			break
 		end
 		local path, query = parsetarget(target)

--- a/lualib/silly/net/http/h2.lua
+++ b/lualib/silly/net/http/h2.lua
@@ -9,6 +9,7 @@ local hpack = require "silly.http2.hpack"
 local builder = require "silly.http2.framebuilder"
 local errno = require "silly.errno"
 
+local type = type
 local next = next
 local error = error
 local pairs = pairs
@@ -140,10 +141,13 @@ local forbidden_headers = {
 	["upgrade"] = true,
 }
 
+global _
+
 --- @class silly.net.http.h2.channel
 --- connection
 --- @field scheme string
 --- @field conn silly.net.tcp.conn|silly.net.tls.conn
+--- @field authority string
 --- @field package writeco thread?
 --- streams
 --- @field package streamidx integer
@@ -224,11 +228,12 @@ local stream_mt = {
 ---@param scheme string
 ---@param conn silly.net.tcp.conn|silly.net.tls.conn
 ---@return silly.net.http.h2.channel
-local function newchannel(scheme, conn)
+local function newchannel(scheme, conn, host)
 	---@type silly.net.http.h2.channel
 	local ch = {
 		--- connection
 		scheme = scheme,
+		authority = host,
 		conn = conn,
 		--- streams
 		streamidx = -1,
@@ -701,6 +706,8 @@ local function stream_writeheader(s, header, endstream)
 	local ch = s.channel
 	local id = s.id
 	if s.active then --client request stream
+		-- stream ID may have advanced since openstream() if other streams
+		-- were sent first; reassign to the latest ID in that case
 		local idx = ch.streamidx
 		if id ~= idx then
 			local streams = ch.streams
@@ -710,13 +717,18 @@ local function stream_writeheader(s, header, endstream)
 			s.id = id
 			streams[id] = s
 		end
-		local host = header["host"]
+		-- :authority replaces host in HTTP/2; save/restore prevents mutating caller's table.
+		-- host must not be sent as a regular header (RFC 7540 Section 8.1.2.2).
+		-- header keys are assumed to be pre-normalized to lowercase
+		-- (by client.lua do_with_redirects or the caller of M.request).
+		local saved_host = header["host"]
 		header["host"] = nil
 		hdat = hpack_pack(ch.sendhpack, header,
-			":authority", host,
+			":authority", ch.authority,
 			":method", s.method,
 			":path", s.path,
 			":scheme", ch.scheme)
+		header["host"] = saved_host
 	else --server response stream
 		hdat = hpack_pack(ch.sendhpack, header, ":status", s.status)
 	end
@@ -1701,9 +1713,10 @@ end
 
 ---@param scheme string
 ---@param conn silly.net.tcp.conn|silly.net.tls.conn
+---@param host string
 ---@return silly.net.http.h2.channel.client?, string? error
-function M.newchannel(scheme, conn)
-	local ch = newchannel(scheme, conn)
+function M.newchannel(scheme, conn, host)
+	local ch = newchannel(scheme, conn, host)
 	--- @cast ch silly.net.http.h2.channel.client
 	ch.scheme = scheme
 	ch.openwaitq = queue.new()
@@ -1717,7 +1730,7 @@ end
 ---@param handler fun(s:silly.net.http.h2.stream)
 ---@param conn silly.net.tcp.conn|silly.net.tls.conn
 function M.httpd(handler, conn)
-	local ch = newchannel("https", conn)
+	local ch = newchannel("https", conn, "")
 	--- @cast ch silly.net.http.h2.channel.server
 	ch.handler = handler
 	local ok = handshake_as_server(ch)

--- a/lualib/silly/net/http/helper.lua
+++ b/lualib/silly/net/http/helper.lua
@@ -1,19 +1,13 @@
-local addr = require "silly.net.addr"
-
-local pairs = pairs
-local tonumber = tonumber
-local type = type
-local format = string.format
 local gsub = string.gsub
 local find = string.find
 local sub = string.sub
-local match = string.match
-local gmatch = string.gmatch
+local format = string.format
 local byte = string.byte
-local concat = table.concat
 local utf8char = utf8.char
-local strchar = string.char
-local parse_addr = addr.parse
+local tonumber = tonumber
+local parsequery = require "silly.net.http.url".parsequery
+
+global _
 
 local helper = {}
 
@@ -33,78 +27,18 @@ function helper.htmlunescape(html)
 	return html
 end
 
-local function encode(val)
-	return gsub(val, "([^0-9a-zA-Z$_%.!*(),-])", function(n)
-		return format("%%%02X", byte(n, 1))
-	end)
-end
-
-function helper.urlencode(val)
-	if type(val) == "table" then
-		local buf = {}
-		for k, v in pairs(val) do
-			buf[#buf+1] = format("%s=%s", encode(k), encode(v))
-		end
-		return concat(buf, "&")
-	else
-		return encode(val)
-	end
-end
-
-local function urldecode(s)
-	return gsub(s, "%%([0-9a-fA-F][0-9a-fA-F])", function (h)
-		return strchar(tonumber(h, 16))
-	end)
-end
-
-helper.urldecode = urldecode
-
-local default_port = {
-	["https"] = "443",
-	["wss"] = "443",
-	["http"] = "80",
-	["ws"] = "80",
-}
-
-
-function helper.parseurl(url)
-	local default = false
-	local scheme, hostport, path = match(url, "^([^:]+)://([^/?]*)(.*)")
-	if not scheme then
-		return nil, "Invalid url"
-	end
-	if path == "" or byte(path, 1) == 63 then -- '?'
-		path = "/" .. path
-	end
-	local host, port = parse_addr(hostport)
-	if not host then
-		return nil, "Invalid url"
-	end
-	if not port then
-		port = default_port[scheme]
-		if not port then
-			return nil, "Unsupported scheme"
-		end
-		default = true
-	end
-	return scheme, host, port, path, default
-end
-
+---Parse an HTTP request target into path and query components.
+---@param target string
+---@return string path, table<string, string> query
 function helper.parsetarget(target)
-	local query = {}
 	local start = find(target, "?", 1, true)
 	if not start then
-		return target, query
+		return target, {}
 	end
 	local path = sub(target, 1, start - 1)
 	path = path == "" and "/" or path
 	local querystring = sub(target, start + 1)
-	if querystring ~= "" then
-		for k, v in gmatch(querystring, "([^=&]+)=([^&]+)") do
-			query[urldecode(k)] = urldecode(v)
-		end
-	end
-	return path, query
+	return path, parsequery(querystring)
 end
 
 return helper

--- a/lualib/silly/net/http/url.lua
+++ b/lualib/silly/net/http/url.lua
@@ -1,0 +1,210 @@
+local addr = require "silly.net.addr"
+
+local pairs = pairs
+local type = type
+local tonumber = tonumber
+local format = string.format
+local gsub = string.gsub
+local sub = string.sub
+local match = string.match
+local gmatch = string.gmatch
+local byte = string.byte
+local concat = table.concat
+local strchar = string.char
+local lower = string.lower
+local parse_addr = addr.parse
+local join_addr = addr.join
+
+global _
+
+local M = {}
+
+--- @class silly.net.http.url.parts
+--- @field scheme string
+--- @field host string       hostname only (no port)
+--- @field port string       port as string
+--- @field authority string  "host" or "host:port" — for Host/:authority header
+--- @field path string       request target (path + query + fragment)
+
+local default_port = {
+	["https"] = "443",
+	["wss"] = "443",
+	["http"] = "80",
+	["ws"] = "80",
+}
+
+local function makeurl(scheme, host, port, path)
+	scheme = lower(scheme)
+	host = lower(host)
+	if not port then
+		port = default_port[scheme]
+		if not port then
+			return nil, "Unsupported scheme"
+		end
+	end
+	local authority
+	if default_port[scheme] ~= port then
+		authority = join_addr(host, port)
+	else
+		authority = join_addr(host)
+	end
+	return {
+		scheme = scheme,
+		host = host,
+		port = port,
+		authority = authority,
+		path = path,
+	}
+end
+
+local function parsehostport(scheme, hostport, path)
+	if path == "" or byte(path, 1) == 63 then -- '?'
+		path = "/" .. path
+	end
+	local host, port = parse_addr(hostport)
+	if not host then
+		return nil, "Invalid url"
+	end
+	return makeurl(scheme, host, port, path)
+end
+
+---Parse a URL into a structured object.
+---@param url string
+---@return silly.net.http.url.parts? result, string? error
+function M.parse(url)
+	local scheme, hostport, path = match(url, "^([a-zA-Z][a-zA-Z0-9+.-]*)://([^/?]*)(.*)")
+	if not scheme then
+		return nil, "Invalid url"
+	end
+	return parsehostport(scheme, hostport, path)
+end
+
+---Resolve a reference against a base URL (RFC 3986 Section 5).
+---@param base_url string
+---@param ref string
+---@return silly.net.http.url.parts? result, string? error
+function M.resolve(base_url, ref)
+	-- absolute URL
+	local scheme, hostport, path = match(ref, "^([a-zA-Z][a-zA-Z0-9+.-]*)://([^/?]*)(.*)")
+	if scheme then
+		return parsehostport(scheme, hostport, path)
+	end
+	-- parse base for non-absolute refs
+	local bscheme, bhostport, bpath = match(base_url, "^([a-zA-Z][a-zA-Z0-9+.-]*)://([^/?]*)(.*)")
+	if not bscheme then
+		return nil, "Invalid base url"
+	end
+	if bpath == "" or byte(bpath, 1) == 63 then -- '?'
+		bpath = "/" .. bpath
+	end
+	local ref_first, ref_second = byte(ref, 1), byte(ref, 2)
+	-- protocol-relative
+	if ref_first == 47 and ref_second == 47 then -- '//'
+		local hostport, path = match(ref, "^//([^/?]*)(.*)")
+		return parsehostport(bscheme, hostport, path)
+	end
+	-- same origin, resolve path
+	local bhost, bport = parse_addr(bhostport)
+	if not bhost then
+		return nil, "Invalid url"
+	end
+	-- query-only
+	if ref_first == 63 then -- '?'
+		return makeurl(bscheme, bhost, bport, match(bpath, "^([^?#]*)") .. ref)
+	end
+	-- fragment-only
+	if ref_first == 35 then -- '#'
+		return makeurl(bscheme, bhost, bport, match(bpath, "^([^#]*)") .. ref)
+	end
+	-- root-relative
+	if ref_first == 47 then -- '/'
+		return makeurl(bscheme, bhost, bport, ref)
+	end
+	-- path-relative
+	-- dot segments (../  ./) are not normalized; extremely rare in HTTP redirects.
+	-- servers/routers that care should normalize the request target themselves (RFC 9112 §3.6).
+	local dir = match(bpath, "^(.*/)")
+	return makeurl(bscheme, bhost, bport, (dir or "/") .. ref)
+end
+
+---Reconstruct the full URL string from a parsed url object.
+---@param u silly.net.http.url.parts
+---@return string
+function M.build(u)
+	return format("%s://%s%s", u.scheme, u.authority, u.path)
+end
+
+-- RFC 3986 path: unreserved / pct-encoded / sub-delims / ":" / "@" / "/"
+local function pathescapechar(val)
+	return gsub(val, "([^0-9a-zA-Z$_%.!*(),;:@&=+~/%-])", function(n)
+		return format("%%%02X", byte(n, 1))
+	end)
+end
+
+-- application/x-www-form-urlencoded: unreserved + "*", "-", ".", "_"
+-- "*" is a sub-delimiter (RFC 3986 Section 2.2) left unencoded in query strings
+-- spaces become "+"
+local function queryescapechar(val)
+	return gsub(val, "([^0-9a-zA-Z%*%-%._])", function(n)
+		if n == " " then
+			return "+"
+		end
+		return format("%%%02X", byte(n, 1))
+	end)
+end
+
+---Percent-encode a string for use in URL path segments (RFC 3986).
+---@param val string
+---@return string
+function M.pathescape(val)
+	return pathescapechar(val)
+end
+
+---Encode a string or table for use in URL query strings (application/x-www-form-urlencoded).
+---@param val string|table<string, string>
+---@return string
+function M.queryescape(val)
+	if type(val) == "table" then
+		local buf = {}
+		for k, v in pairs(val) do
+			buf[#buf + 1] = format("%s=%s", queryescapechar(k), queryescapechar(v))
+		end
+		return concat(buf, "&")
+	end
+	return queryescapechar(val)
+end
+
+---Percent-decode a string (RFC 3986). Only handles %XX sequences.
+---@param s string
+---@return string
+local function pathunescape(s)
+	return gsub(s, "%%([0-9a-fA-F][0-9a-fA-F])", function(h)
+		return strchar(tonumber(h, 16))
+	end)
+end
+
+---Percent-decode a string for query context. Handles %XX and converts '+' to space.
+---@param s string
+---@return string
+local function queryunescape(s)
+	return pathunescape(gsub(s, "%+", " "))
+end
+
+---Parse a query string into a key-value table (like Go's url.ParseQuery).
+---@param query string
+---@return table<string, string> result
+function M.parsequery(query)
+	local result = {}
+	if query and query ~= "" then
+		for k, v in gmatch(query, "([^=&]+)=?([^&]*)") do
+			result[queryunescape(k)] = queryunescape(v)
+		end
+	end
+	return result
+end
+
+
+M.pathunescape = pathunescape
+M.queryunescape = queryunescape
+
+return M

--- a/lualib/silly/net/websocket.lua
+++ b/lualib/silly/net/websocket.lua
@@ -2,7 +2,7 @@ local http = require "silly.net.http"
 local base64 = require "silly.encoding.base64"
 local sha1 = require "silly.crypto.hash".new("sha1")
 local utils = require "silly.crypto.utils"
-local helper = require "silly.net.http.helper"
+local url = require "silly.net.http.url"
 local dns = require "silly.net.dns"
 local tcp = require "silly.net.tcp"
 local tls = require "silly.net.tls"
@@ -19,7 +19,7 @@ local unpack = string.unpack
 local format = string.format
 local xor = utils.xor
 local randomkey = utils.randomkey
-local parseurl = helper.parseurl
+local parseurl = url.parse
 local join_addr = addr.join
 
 ---@class silly.net.websocket
@@ -238,9 +238,16 @@ local function handshake(stream)
 	end
 	for k, v in pairs(checklist) do
 		local verify = header[k]
-		if verify and verify ~= v then
-			respond(stream, 400, {})
-			return false, "Header " .. k .. " mismatch"
+		if verify then
+			if k == "connection" then
+				if not verify:lower():find("upgrade", 1, true) then
+					respond(stream, 400, {})
+					return false, "Header " .. k .. " mismatch"
+				end
+			elseif verify ~= v then
+				respond(stream, 400, {})
+				return false, "Header " .. k .. " mismatch"
+			end
 		end
 	end
 	local key = header["sec-websocket-key"]
@@ -287,31 +294,30 @@ end
 ---@return silly.net.websocket.socket|nil, string|nil
 function M.connect(url, header)
 	local conn, err
-	local scheme, host, port, path = parseurl(url)
-	if not scheme then
-		return nil, host
+	local u, err = parseurl(url)
+	if not u then
+		return nil, err
 	end
-	local ip, err = dns.lookup(host, dns.A)
+	local ip, err = dns.lookup(u.host, dns.A)
 	if not ip then
-		return nil, format("dns lookup %s failed: %s", host, err)
+		return nil, format("dns lookup %s failed: %s", u.host, err)
 	end
-	local addr = join_addr(ip, port)
-	if scheme == "wss" then
-		conn, err = tls.connect(addr, {hostname = host})
+	local a = join_addr(ip, u.port)
+	if u.scheme == "wss" then
+		conn, err = tls.connect(a, {hostname = u.host})
 	else
-		conn, err = tcp.connect(addr)
+		conn, err = tcp.connect(a)
 	end
 	if not conn then
 		return nil, err
 	end
 	header = header or {}
 	header["connection"] = "Upgrade"
-	header["host"] = host
 	header["upgrade"] = "websocket"
 	header["sec-websocket-version"] = 13
 	header["sec-websocket-key"] = base64.encode(randomkey(16))
-	local stream = h1.newstream(scheme, conn)
-	local ok, err = stream:request("GET", path, header)
+	local stream = h1.newstream(u.scheme, conn, u.authority)
+	local ok, err = stream:request("GET", u.path, header)
 	if not ok then
 		stream:close()
 		return nil, err

--- a/lualib/types/silly/net/addr.lua
+++ b/lualib/types/silly/net/addr.lua
@@ -9,7 +9,7 @@ local M = {}
 function M.parse(addr) end
 
 ---@param host string?
----@param port string
+---@param port string?
 ---@return string
 function M.join(host, port) end
 

--- a/test/testaddr.lua
+++ b/test/testaddr.lua
@@ -149,6 +149,36 @@ testaux.case("Test 15: join round-trip with parse", function()
 	testaux.asserteq(result, "[::1]:5432", "Test 15.3: IPv6 round-trip")
 end)
 
+testaux.case("Test 15b: join without port", function()
+	-- IPv4 no port
+	local result = addr.join("127.0.0.1")
+	testaux.asserteq(result, "127.0.0.1", "Test 15b.1: IPv4 no port")
+
+	-- hostname no port
+	result = addr.join("example.com")
+	testaux.asserteq(result, "example.com", "Test 15b.2: hostname no port")
+
+	-- IPv6 no port (brackets added)
+	result = addr.join("::1")
+	testaux.asserteq(result, "[::1]", "Test 15b.3: IPv6 no port gets brackets")
+
+	-- IPv6 full address no port
+	result = addr.join("2001:db8::1")
+	testaux.asserteq(result, "[2001:db8::1]", "Test 15b.4: full IPv6 no port")
+
+	-- already-bracketed IPv6 no port
+	result = addr.join("[::1]")
+	testaux.asserteq(result, "[::1]", "Test 15b.5: no double brackets without port")
+
+	-- empty host, no port
+	result = addr.join(nil)
+	testaux.asserteq(result, "", "Test 15b.6: nil host no port is empty")
+
+	-- empty host string, no port
+	result = addr.join("")
+	testaux.asserteq(result, "", "Test 15b.7: empty host no port is empty")
+end)
+
 ---------- isv4 ----------
 
 testaux.case("Test 16: isv4", function()

--- a/test/testhttp.lua
+++ b/test/testhttp.lua
@@ -20,13 +20,16 @@ local errno = require "silly.errno"
 local EEOF<const> = errno.EOF
 local ETIMEDOUT<const> = errno.TIMEDOUT
 
+local set_nil = true
 local server_handler
 
 local server = http.listen {
 	addr = "127.0.0.1:8080",
 	handler = function(stream)
 		server_handler(stream)
-		server_handler = nil
+		if set_nil then
+			server_handler = nil
+		end
 	end
 }
 
@@ -43,11 +46,20 @@ local function wait_done()
 	end
 end
 
-testaux.case("Test 1: Basic HTTP Server Setup", function()
+local function case(name, fn)
+	testaux.case(name, function()
+		local ok, err = pcall(fn)
+		server_handler = nil
+		set_nil = true
+		if not ok then error(err) end
+	end)
+end
+
+case("Test 1: Basic HTTP Server Setup", function()
 	testaux.asserteq(not not server, true, "Server should start successfully")
 end)
 
-testaux.case("Test 2: Malformed HTTP Request Headers", function()
+case("Test 2: Malformed HTTP Request Headers", function()
 	-- Send invalid HTTP method
 	local fd = tcp.connect("127.0.0.1:8080")
 	testaux.assertneq(fd, nil, "Test 2.1: Client connection should succeed")
@@ -71,7 +83,7 @@ testaux.case("Test 2: Malformed HTTP Request Headers", function()
 	tcp.close(fd)
 end)
 
-testaux.case("Test 3: HTTP/1.1 Chunked Transfer", function()
+case("Test 3: HTTP/1.1 Chunked Transfer", function()
 	server_handler = function(stream)
 		stream:respond(200, {
 			["content-type"] = "text/plain",
@@ -85,7 +97,7 @@ testaux.case("Test 3: HTTP/1.1 Chunked Transfer", function()
 	wait_done()
 end)
 
-testaux.case("Test 4: HTTP Header Size Limits", function()
+case("Test 4: HTTP Header Size Limits", function()
 	server_handler = function(stream)
 		stream:respond(200, {
 			["content-type"] = "text/plain",
@@ -114,7 +126,7 @@ testaux.case("Test 4: HTTP Header Size Limits", function()
 	wait_done()
 end)
 
-testaux.case("Test 5: Connection Keep-Alive", function()
+case("Test 5: Connection Keep-Alive", function()
 	local function x(stream)
 		stream:respond(200, {
 			["content-type"] = "text/plain",
@@ -156,7 +168,7 @@ testaux.case("Test 5: Connection Keep-Alive", function()
 	wait_done()
 end)
 
-testaux.case("Test 6: Test connection broken", function()
+case("Test 6: Test connection broken", function()
 	-- test server connection broken
 	server_handler = function(stream)
 		testaux.assertneq(stream.remoteaddr, nil, "Test 6.2: Server stream contains remoteaddr")
@@ -175,7 +187,7 @@ testaux.case("Test 6: Test connection broken", function()
 	wait_done()
 end)
 
-testaux.case("Test 7: HTTP Content-Length and Request Body", function()
+case("Test 7: HTTP Content-Length and Request Body", function()
 	server_handler = function(stream)
 		local body, err = stream:readall()
 		testaux.asserteq(body, "Hello Server", "Test 7.1: Server should receive request body")
@@ -195,7 +207,7 @@ testaux.case("Test 7: HTTP Content-Length and Request Body", function()
 	wait_done()
 end)
 
-testaux.case("Test 8: HTTP Query Parameters", function()
+case("Test 8: HTTP Query Parameters", function()
 	server_handler = function(stream)
 		local query = stream.query
 		testaux.asserteq(query["name"], "test", "Test 8.1: Server should receive query parameters")
@@ -214,7 +226,7 @@ testaux.case("Test 8: HTTP Query Parameters", function()
 	wait_done()
 end)
 
-testaux.case("Test 9: HTTP Status Codes", function()
+case("Test 9: HTTP Status Codes", function()
 	local status_codes = {
 		[200] = "OK",
 		[201] = "Created",
@@ -253,7 +265,7 @@ testaux.case("Test 9: HTTP Status Codes", function()
 	end
 end)
 
-testaux.case("Test 10: HTTP Headers Processing", function()
+case("Test 10: HTTP Headers Processing", function()
 	server_handler = function(stream)
 		local user_agent = stream.header["user-agent"] or ""
 		local accept = stream.header["accept"] or ""
@@ -296,7 +308,7 @@ testaux.case("Test 10: HTTP Headers Processing", function()
 	wait_done()
 end)
 
-testaux.case("Test 11: Content-Type and Accept Headers", function()
+case("Test 11: Content-Type and Accept Headers", function()
 	local function x(stream)
 		local accept = stream.header["accept"] or "*/*"
 		if accept:find("application/json", 1, true) then
@@ -341,7 +353,7 @@ testaux.case("Test 11: Content-Type and Accept Headers", function()
 	wait_done()
 end)
 
-testaux.case("Test 12: client.request API - Basic GET", function()
+case("Test 12: client.request API - Basic GET", function()
 	server_handler = function(stream)
 		testaux.asserteq(stream.method, "GET", "Test 12.1: Method should be GET")
 		testaux.asserteq(stream.path, "/api/test", "Test 12.2: Path should be /api/test")
@@ -365,7 +377,7 @@ testaux.case("Test 12: client.request API - Basic GET", function()
 	wait_done()
 end)
 
-testaux.case("Test 13: client.request API - POST with body", function()
+case("Test 13: client.request API - POST with body", function()
 	server_handler = function(stream)
 		testaux.asserteq(stream.method, "POST", "Test 13.1: Method should be POST")
 		local body, err = stream:readall()
@@ -392,7 +404,7 @@ testaux.case("Test 13: client.request API - POST with body", function()
 	wait_done()
 end)
 
-testaux.case("Test 14: client.request API - Chunked request", function()
+case("Test 14: client.request API - Chunked request", function()
 	server_handler = function(stream)
 		local body, err = stream:readall()
 		testaux.asserteq(body, "part1part2part3", "Test 14.1: body should be concatenated")
@@ -417,7 +429,7 @@ testaux.case("Test 14: client.request API - Chunked request", function()
 	wait_done()
 end)
 
-testaux.case("Test 15: client.request API - HEAD request", function()
+case("Test 15: client.request API - HEAD request", function()
 	server_handler = function(stream)
 		testaux.asserteq(stream.method, "HEAD", "Test 15.1: Method should be HEAD")
 		stream:respond(200, {
@@ -439,7 +451,7 @@ testaux.case("Test 15: client.request API - HEAD request", function()
 	wait_done()
 end)
 
-testaux.case("Test 16: client.request API - Incremental read from chunked", function()
+case("Test 16: client.request API - Incremental read from chunked", function()
 	server_handler = function(stream)
 		stream:respond(200, {
 			["transfer-encoding"] = "chunked",
@@ -469,7 +481,7 @@ testaux.case("Test 16: client.request API - Incremental read from chunked", func
 	wait_done()
 end)
 
-testaux.case("Test 17: client.request API - closewrite with data", function()
+case("Test 17: client.request API - closewrite with data", function()
 	server_handler = function(stream)
 		local body, err = stream:readall()
 		testaux.asserteq(body, "Final", "Test 17.1: body should be 'Final'")
@@ -494,7 +506,7 @@ testaux.case("Test 17: client.request API - closewrite with data", function()
 	wait_done()
 end)
 
-testaux.case("Test 18: Chunked with trailer headers", function()
+case("Test 18: Chunked with trailer headers", function()
 	server_handler = function(stream)
 		stream:respond(200, {
 			["content-type"] = "text/plain",
@@ -521,7 +533,7 @@ testaux.case("Test 18: Chunked with trailer headers", function()
 	wait_done()
 end)
 
-testaux.case("Test 19: Connection pool - H1 reuse", function()
+case("Test 19: Connection pool - H1 reuse", function()
 	local c = http.newclient({
 		max_idle_per_host = 2,
 		idle_timeout = 2000,
@@ -560,7 +572,7 @@ testaux.case("Test 19: Connection pool - H1 reuse", function()
 	wait_done()
 end)
 
-testaux.case("Test 20: Connection pool - max_idle_per_host limit", function()
+case("Test 20: Connection pool - max_idle_per_host limit", function()
 	local c = http.newclient({
 		max_idle_per_host = 2,
 		idle_timeout = 2000,
@@ -595,7 +607,7 @@ testaux.case("Test 20: Connection pool - max_idle_per_host limit", function()
 	-- Third connection should be closed when released
 end)
 
-testaux.case("Test 21: Connection pool - chunked response reuse", function()
+case("Test 21: Connection pool - chunked response reuse", function()
 	local c = http.newclient({
 		max_idle_per_host = 2,
 		idle_timeout = 2000,
@@ -634,7 +646,7 @@ testaux.case("Test 21: Connection pool - chunked response reuse", function()
 	wait_done()
 end)
 
-testaux.case("Test 22: stream:read(n) - content-length partial reads", function()
+case("Test 22: stream:read(n) - content-length partial reads", function()
 	server_handler = function(stream)
 		stream:respond(200, {
 			["content-type"] = "text/plain",
@@ -673,7 +685,7 @@ testaux.case("Test 22: stream:read(n) - content-length partial reads", function(
 	wait_done()
 end)
 
-testaux.case("Test 23: stream:read(n) - chunked partial reads", function()
+case("Test 23: stream:read(n) - chunked partial reads", function()
 	server_handler = function(stream)
 		stream:respond(200, {
 			["transfer-encoding"] = "chunked",
@@ -727,7 +739,7 @@ testaux.case("Test 23: stream:read(n) - chunked partial reads", function()
 	wait_done()
 end)
 
-testaux.case("Test 24: stream:read(n) - read more than available with content-length", function()
+case("Test 24: stream:read(n) - read more than available with content-length", function()
 	server_handler = function(stream)
 		stream:respond(200, {
 			["content-type"] = "text/plain",
@@ -759,7 +771,7 @@ testaux.case("Test 24: stream:read(n) - read more than available with content-le
 	wait_done()
 end)
 
-testaux.case("Test 25: stream:read(n) - read more than available with chunked", function()
+case("Test 25: stream:read(n) - read more than available with chunked", function()
 	server_handler = function(stream)
 		stream:respond(200, {
 			["transfer-encoding"] = "chunked",
@@ -785,7 +797,7 @@ testaux.case("Test 25: stream:read(n) - read more than available with chunked", 
 	wait_done()
 end)
 
-testaux.case("Test 26: Timeout marks stream as broken", function()
+case("Test 26: Timeout marks stream as broken", function()
 	server_handler = function(stream)
 		stream:respond(200, {
 			["content-length"] = 20,
@@ -821,7 +833,7 @@ testaux.case("Test 26: Timeout marks stream as broken", function()
 	wait_done()
 end)
 
-testaux.case("Test 27: read() exceeding Content-Length", function()
+case("Test 27: read() exceeding Content-Length", function()
 	server_handler = function(stream)
 		stream:respond(200, {
 			["content-length"] = 10,
@@ -846,7 +858,7 @@ testaux.case("Test 27: read() exceeding Content-Length", function()
 	wait_done()
 end)
 
-testaux.case("Test 28: read() after chunked ends", function()
+case("Test 28: read() after chunked ends", function()
 	server_handler = function(stream)
 		stream:respond(200, {
 			["transfer-encoding"] = "chunked",
@@ -873,7 +885,7 @@ testaux.case("Test 28: read() after chunked ends", function()
 	wait_done()
 end)
 
-testaux.case("Test 29: read() partial, then readall() rest - Content-Length", function()
+case("Test 29: read() partial, then readall() rest - Content-Length", function()
 	server_handler = function(stream)
 		stream:respond(200, {
 			["content-length"] = 20,
@@ -898,7 +910,7 @@ testaux.case("Test 29: read() partial, then readall() rest - Content-Length", fu
 	wait_done()
 end)
 
-testaux.case("Test 30: read() partial, then readall() rest - Chunked", function()
+case("Test 30: read() partial, then readall() rest - Chunked", function()
 	server_handler = function(stream)
 		stream:respond(200, {
 			["transfer-encoding"] = "chunked",
@@ -928,7 +940,7 @@ testaux.case("Test 30: read() partial, then readall() rest - Chunked", function(
 	wait_done()
 end)
 
-testaux.case("Test 31: Connection broken - Content-Length incomplete", function()
+case("Test 31: Connection broken - Content-Length incomplete", function()
 	server_handler = function(stream)
 		stream:respond(200, {
 			["content-length"] = 100,
@@ -955,7 +967,7 @@ testaux.case("Test 31: Connection broken - Content-Length incomplete", function(
 	testaux.asserteq(err2, stream.err, "Test 31.6: Should return cached error")
 end)
 
-testaux.case("Test 32: Connection broken - Chunked incomplete", function()
+case("Test 32: Connection broken - Chunked incomplete", function()
 	server_handler = function(stream)
 		stream:respond(200, {
 			["transfer-encoding"] = "chunked",
@@ -978,7 +990,7 @@ testaux.case("Test 32: Connection broken - Chunked incomplete", function()
 end)
 
 
-testaux.case("Test 33: read() returns buffered data before network read", function()
+case("Test 33: read() returns buffered data before network read", function()
 	server_handler = function(stream)
 		stream:respond(200, {
 			["content-length"] = 20,
@@ -1004,7 +1016,7 @@ testaux.case("Test 33: read() returns buffered data before network read", functi
 	wait_done()
 end)
 
-testaux.case("Test 34: GET with gzip compression", function()
+case("Test 34: GET with gzip compression", function()
 	local original_data = "Hello World! This is a test data that should be compressed with gzip. " ..
 		"The more data we have, the better compression ratio we get. " ..
 		"So let's add some more text here to make it longer and more compressible."
@@ -1032,7 +1044,7 @@ testaux.case("Test 34: GET with gzip compression", function()
 	wait_done()
 end)
 
-testaux.case("Test 35: POST with gzip compression response", function()
+case("Test 35: POST with gzip compression response", function()
 	local request_data = "Request from client"
 	local response_data = "This is a compressed response from server. " ..
 		"Adding more text to make compression more effective."
@@ -1063,7 +1075,7 @@ testaux.case("Test 35: POST with gzip compression response", function()
 	wait_done()
 end)
 
-testaux.case("Test 36: GET without gzip (no Content-Encoding)", function()
+case("Test 36: GET without gzip (no Content-Encoding)", function()
 	local original_data = "Uncompressed data"
 
 	server_handler = function(stream)
@@ -1081,7 +1093,7 @@ testaux.case("Test 36: GET without gzip (no Content-Encoding)", function()
 	wait_done()
 end)
 
-testaux.case("Test 37: GET with Accept-Encoding header check", function()
+case("Test 37: GET with Accept-Encoding header check", function()
 	server_handler = function(stream)
 		local accept_encoding = stream.header["accept-encoding"]
 		testaux.asserteq(accept_encoding, "gzip", "Test 37.1: Client should send Accept-Encoding: gzip")
@@ -1098,7 +1110,7 @@ testaux.case("Test 37: GET with Accept-Encoding header check", function()
 	wait_done()
 end)
 
-testaux.case("Test 38: Query parameters with percent-encoding", function()
+case("Test 38: Query parameters with percent-encoding", function()
 	server_handler = function(stream)
 		local query = stream.query
 		testaux.asserteq(query["name"], "你好", "Test 38.1: Percent-encoded value should be decoded")
@@ -1117,7 +1129,7 @@ testaux.case("Test 38: Query parameters with percent-encoding", function()
 	wait_done()
 end)
 
-testaux.case("Test 39: Invalid URL error handling", function()
+case("Test 39: Invalid URL error handling", function()
 	local response, err = httpc:get("not-a-url")
 	testaux.asserteq(response, nil, "Test 39.1: Invalid URL should return nil")
 	testaux.assertneq(err, nil, "Test 39.2: Invalid URL should return error")
@@ -1128,103 +1140,114 @@ testaux.case("Test 39: Invalid URL error handling", function()
 end)
 
 local helper = require "silly.net.http.helper"
+local url = require "silly.net.http.url"
 
-testaux.case("Test 40: urlencode encodes both keys and values", function()
-	local result = helper.urlencode({["a b"] = "c&d"})
-	testaux.assertneq(result, nil, "Test 40.1: urlencode should return result")
-	-- In Lua string literals, % has no special meaning, so "a%20b" is literal a%20b
-	local found_key = result:find("a%20b", 1, true)
-	testaux.assertneq(found_key, nil, "Test 40.2: Key should be percent-encoded")
+case("Test 40: queryescape encodes both keys and values", function()
+	local result = url.queryescape({["a b"] = "c&d"})
+	testaux.assertneq(result, nil, "Test 40.1: queryescape should return result")
+	local found_key = result:find("a+b", 1, true)
+	testaux.assertneq(found_key, nil, "Test 40.2: Key should be encoded")
 	local found_val = result:find("c%26d", 1, true)
 	testaux.assertneq(found_val, nil, "Test 40.3: Value should be percent-encoded")
 end)
 
-testaux.case("Test 41: parseurl comprehensive", function()
+case("Test 41: parseurl comprehensive", function()
 	-- Normal HTTP URL with path
-	local scheme, host, port, path, default = helper.parseurl("http://example.com/path")
-	testaux.asserteq(scheme, "http", "Test 41.1: scheme")
-	testaux.asserteq(host, "example.com", "Test 41.2: host")
-	testaux.asserteq(port, "80", "Test 41.3: default port 80")
-	testaux.asserteq(path, "/path", "Test 41.4: path")
-	testaux.asserteq(default, true, "Test 41.5: default flag true")
+	local u = url.parse("http://example.com/path")
+	testaux.asserteq(u.scheme, "http", "Test 41.1: scheme")
+	testaux.asserteq(u.host, "example.com", "Test 41.2: host")
+	testaux.asserteq(u.port, "80", "Test 41.3: default port 80")
+	testaux.asserteq(u.path, "/path", "Test 41.4: path")
+	testaux.asserteq(u.authority, "example.com", "Test 41.5: authority omits default port")
 
 	-- URL with explicit port
-	scheme, host, port, path, default = helper.parseurl("http://example.com:8080/api/v1")
-	testaux.asserteq(host, "example.com", "Test 41.6: host with port")
-	testaux.asserteq(port, "8080", "Test 41.7: explicit port")
-	testaux.asserteq(path, "/api/v1", "Test 41.8: multi-segment path")
-	testaux.asserteq(default, false, "Test 41.9: default flag false")
+	u = url.parse("http://example.com:8080/api/v1")
+	testaux.asserteq(u.host, "example.com", "Test 41.6: host with port")
+	testaux.asserteq(u.port, "8080", "Test 41.7: explicit port")
+	testaux.asserteq(u.path, "/api/v1", "Test 41.8: multi-segment path")
+	testaux.asserteq(u.authority, "example.com:8080", "Test 41.9: authority includes explicit port")
 
 	-- HTTPS URL without path (empty path becomes "/")
-	scheme, host, port, path = helper.parseurl("https://secure.example.com")
-	testaux.asserteq(scheme, "https", "Test 41.10: https scheme")
-	testaux.asserteq(port, "443", "Test 41.11: default https port")
-	testaux.asserteq(path, "/", "Test 41.12: empty path becomes /")
+	u = url.parse("https://secure.example.com")
+	testaux.asserteq(u.scheme, "https", "Test 41.10: https scheme")
+	testaux.asserteq(u.port, "443", "Test 41.11: default https port")
+	testaux.asserteq(u.path, "/", "Test 41.12: empty path becomes /")
 
 	-- URL with query only (no path before ?)
-	scheme, host, port, path = helper.parseurl("http://example.com?key=value")
-	testaux.asserteq(host, "example.com", "Test 41.13: host before query")
-	testaux.asserteq(path, "/?key=value", "Test 41.14: query-only path gets / prefix")
+	u = url.parse("http://example.com?key=value")
+	testaux.asserteq(u.host, "example.com", "Test 41.13: host before query")
+	testaux.asserteq(u.path, "/?key=value", "Test 41.14: query-only path gets / prefix")
 
 	-- WSS URL
-	scheme, host, port, path = helper.parseurl("wss://ws.example.com/ws")
-	testaux.asserteq(scheme, "wss", "Test 41.15: wss scheme")
-	testaux.asserteq(port, "443", "Test 41.16: wss default port 443")
-	testaux.asserteq(path, "/ws", "Test 41.17: wss path")
+	u = url.parse("wss://ws.example.com/ws")
+	testaux.asserteq(u.scheme, "wss", "Test 41.15: wss scheme")
+	testaux.asserteq(u.port, "443", "Test 41.16: wss default port 443")
+	testaux.asserteq(u.path, "/ws", "Test 41.17: wss path")
 
 	-- WS URL
-	scheme, host, port, path = helper.parseurl("ws://ws.example.com/chat")
-	testaux.asserteq(scheme, "ws", "Test 41.18: ws scheme")
-	testaux.asserteq(port, "80", "Test 41.19: ws default port 80")
+	u = url.parse("ws://ws.example.com/chat")
+	testaux.asserteq(u.scheme, "ws", "Test 41.18: ws scheme")
+	testaux.asserteq(u.port, "80", "Test 41.19: ws default port 80")
 
 	-- IPv6 URL with port
-	scheme, host, port, path = helper.parseurl("http://[::1]:8080/path")
-	testaux.asserteq(host, "::1", "Test 41.20: IPv6 host brackets stripped")
-	testaux.asserteq(port, "8080", "Test 41.21: IPv6 explicit port")
-	testaux.asserteq(path, "/path", "Test 41.22: IPv6 path")
+	u = url.parse("http://[::1]:8080/path")
+	testaux.asserteq(u.host, "::1", "Test 41.20: IPv6 host brackets stripped")
+	testaux.asserteq(u.port, "8080", "Test 41.21: IPv6 explicit port")
+	testaux.asserteq(u.path, "/path", "Test 41.22: IPv6 path")
+	testaux.asserteq(u.authority, "[::1]:8080", "Test 41.39: IPv6 authority with port")
 
 	-- IPv6 URL without port
-	scheme, host, port, path = helper.parseurl("http://[::1]/path")
-	testaux.asserteq(host, "::1", "Test 41.23: IPv6 host without port")
-	testaux.asserteq(port, "80", "Test 41.24: IPv6 default port")
+	u = url.parse("http://[::1]/path")
+	testaux.asserteq(u.host, "::1", "Test 41.23: IPv6 host without port")
+	testaux.asserteq(u.port, "80", "Test 41.24: IPv6 default port")
+	testaux.asserteq(u.authority, "[::1]", "Test 41.40: IPv6 authority default port")
 
 	-- IPv6 URL with query (no path)
-	scheme, host, port, path = helper.parseurl("http://[::1]:9090?q=1")
-	testaux.asserteq(host, "::1", "Test 41.25: IPv6 host before query")
-	testaux.asserteq(port, "9090", "Test 41.26: IPv6 port before query")
-	testaux.asserteq(path, "/?q=1", "Test 41.27: IPv6 query-only gets / prefix")
+	u = url.parse("http://[::1]:9090?q=1")
+	testaux.asserteq(u.host, "::1", "Test 41.25: IPv6 host before query")
+	testaux.asserteq(u.port, "9090", "Test 41.26: IPv6 port before query")
+	testaux.asserteq(u.path, "/?q=1", "Test 41.27: IPv6 query-only gets / prefix")
+	testaux.asserteq(u.authority, "[::1]:9090", "Test 41.41: IPv6 authority with port and query")
 
 	-- Invalid URL - no scheme
-	local r, err = helper.parseurl("example.com/path")
+	local r, err = url.parse("example.com/path")
 	testaux.asserteq(r, nil, "Test 41.28: no scheme returns nil")
 	testaux.assertneq(err, nil, "Test 41.29: no scheme returns error")
 
 	-- Invalid URL - just a string
-	r, err = helper.parseurl("not-a-url")
+	r, err = url.parse("not-a-url")
 	testaux.asserteq(r, nil, "Test 41.30: plain string returns nil")
 
 	-- Unsupported scheme
-	r, err = helper.parseurl("ftp://example.com/file")
+	r, err = url.parse("ftp://example.com/file")
 	testaux.asserteq(r, nil, "Test 41.31: unsupported scheme returns nil")
 	testaux.assertneq(err, nil, "Test 41.32: unsupported scheme returns error")
 
 	-- URL with path, query and fragment
-	scheme, host, port, path = helper.parseurl("http://example.com/path?a=1&b=2#frag")
-	testaux.asserteq(path, "/path?a=1&b=2#frag", "Test 41.33: path includes query and fragment")
+	u = url.parse("http://example.com/path?a=1&b=2#frag")
+	testaux.asserteq(u.path, "/path?a=1&b=2#frag", "Test 41.33: path includes query and fragment")
 
 	-- URL with port and query
-	scheme, host, port, path = helper.parseurl("http://example.com:3000/api?token=abc")
-	testaux.asserteq(host, "example.com", "Test 41.34: host with port and query")
-	testaux.asserteq(port, "3000", "Test 41.35: port with query")
-	testaux.asserteq(path, "/api?token=abc", "Test 41.36: path with query")
+	u = url.parse("http://example.com:3000/api?token=abc")
+	testaux.asserteq(u.host, "example.com", "Test 41.34: host with port and query")
+	testaux.asserteq(u.port, "3000", "Test 41.35: port with query")
+	testaux.asserteq(u.path, "/api?token=abc", "Test 41.36: path with query")
 
-	-- HTTPS with explicit 443 (not default since explicitly specified)
-	scheme, host, port, path, default = helper.parseurl("https://example.com:443/path")
-	testaux.asserteq(port, "443", "Test 41.37: explicit 443")
-	testaux.asserteq(default, false, "Test 41.38: explicit port not default")
+	-- HTTPS with explicit 443
+	u = url.parse("https://example.com:443/path")
+	testaux.asserteq(u.port, "443", "Test 41.37: explicit 443")
+	testaux.asserteq(u.authority, "example.com", "Test 41.38: default port stripped from authority")
+
+	-- IPv6 url.build round-trip
+	u = url.parse("http://[::1]:8080/p")
+	testaux.asserteq(url.build(u), "http://[::1]:8080/p", "Test 41.42: IPv6 build with port")
+	u = url.parse("http://[::1]/p")
+	testaux.asserteq(url.build(u), "http://[::1]/p", "Test 41.43: IPv6 build default port")
+	u = url.parse("https://[2001:db8::1]:443/p")
+	testaux.asserteq(url.build(u), "https://[2001:db8::1]/p", "Test 41.44: IPv6 https default port")
 end)
 
-testaux.case("Test 42: parsetarget comprehensive", function()
+case("Test 42: parsetarget comprehensive", function()
 	-- Path only
 	local path, query = helper.parsetarget("/path")
 	testaux.asserteq(path, "/path", "Test 42.1: path only")
@@ -1278,9 +1301,9 @@ testaux.case("Test 42: parsetarget comprehensive", function()
 	testaux.assertneq(query["a"], nil, "Test 42.22: duplicate key exists")
 
 	-- Space encoded as +
-	-- Note: parsetarget uses urldecode which handles %XX but not +
 	path, query = helper.parsetarget("/path?q=hello+world")
-	testaux.asserteq(query["q"], "hello+world", "Test 42.23: + not decoded as space")
+	testaux.asserteq(query["q"], "hello world", "Test 42.23: + decoded as space")
+
 
 	-- Space encoded as %20
 	path, query = helper.parsetarget("/path?q=hello%20world")
@@ -1297,156 +1320,201 @@ testaux.case("Test 42: parsetarget comprehensive", function()
 	testaux.asserteq(query["limit"], "10", "Test 42.28: limit param")
 end)
 
-testaux.case("Test 43: urlencode comprehensive", function()
+case("Test 43: urlencode comprehensive", function()
 	-- Safe chars pass through
-	local result = helper.urlencode("hello")
+	local result = url.queryescape("hello")
 	testaux.asserteq(result, "hello", "Test 43.1: safe chars unchanged")
 
 	-- Space encoded
-	result = helper.urlencode("hello world")
-	testaux.asserteq(result, "hello%20world", "Test 43.2: space encoded as %20")
+	result = url.queryescape("hello world")
+	testaux.asserteq(result, "hello+world", "Test 43.2: space encoded as +")
 
 	-- Special chars
-	result = helper.urlencode("a&b=c")
+	result = url.queryescape("a&b=c")
 	testaux.asserteq(result, "a%26b%3Dc", "Test 43.3: & and = encoded")
 
 	-- Empty string
-	result = helper.urlencode("")
+	result = url.queryescape("")
 	testaux.asserteq(result, "", "Test 43.4: empty string unchanged")
 
 	-- Safe special chars (should NOT be encoded)
-	result = helper.urlencode("a.b_c$d!e*f(g)h,i-j")
-	testaux.asserteq(result, "a.b_c$d!e*f(g)h,i-j", "Test 43.5: safe specials unchanged")
+	result = url.queryescape("a.b_c$d!e*f(g)h,i-j")
+	testaux.asserteq(result, "a.b_c%24d%21e*f%28g%29h%2Ci-j", "Test 43.5: specials encoded per x-www-form-urlencoded")
 
 	-- Slash is encoded
-	result = helper.urlencode("a/b")
+	result = url.queryescape("a/b")
 	testaux.asserteq(result, "a%2Fb", "Test 43.6: slash encoded")
 
 	-- Alphanumeric pass through
-	result = helper.urlencode("ABCDEFxyz0123456789")
+	result = url.queryescape("ABCDEFxyz0123456789")
 	testaux.asserteq(result, "ABCDEFxyz0123456789", "Test 43.7: alphanumeric unchanged")
 
 	-- Table input - simple pair
-	result = helper.urlencode({key = "value"})
+	result = url.queryescape({key = "value"})
 	testaux.asserteq(result, "key=value", "Test 43.8: simple table")
 
 	-- Table input - special chars in key and value
-	result = helper.urlencode({["a b"] = "c&d"})
-	testaux.assertneq(result:find("a%20b=c%26d", 1, true), nil, "Test 43.9: table key and value encoded")
+	result = url.queryescape({["a b"] = "c&d"})
+	testaux.assertneq(result:find("a+b=c%26d", 1, true), nil, "Test 43.9: table key and value encoded")
 
 	-- Non-ASCII chars get encoded
-	result = helper.urlencode("你")
+	result = url.queryescape("你")
 	testaux.assertneq(result, "你", "Test 43.10: non-ASCII encoded")
 
 	-- Round-trip: encode then decode restores original
 	local original = "hello world & 你好"
-	result = helper.urldecode(helper.urlencode(original))
+	result = url.queryunescape(url.queryescape(original))
 	testaux.asserteq(result, original, "Test 43.11: round-trip encode/decode")
 
 	-- @ sign is encoded
-	result = helper.urlencode("user@host")
+	result = url.queryescape("user@host")
 	testaux.asserteq(result, "user%40host", "Test 43.12: @ encoded")
 
 	-- Hash/pound is encoded
-	result = helper.urlencode("a#b")
+	result = url.queryescape("a#b")
 	testaux.asserteq(result, "a%23b", "Test 43.13: # encoded")
 
 	-- Percent itself is encoded
-	result = helper.urlencode("100%")
+	result = url.queryescape("100%")
 	testaux.asserteq(result, "100%25", "Test 43.14: % encoded as %25")
 end)
 
-testaux.case("Test 44: urldecode comprehensive", function()
+case("Test 44: urldecode comprehensive", function()
 	-- Basic decode
-	local result = helper.urldecode("hello%20world")
+	local result = url.pathunescape("hello%20world")
 	testaux.asserteq(result, "hello world", "Test 44.1: %20 decoded to space")
 
 	-- No encoding
-	result = helper.urldecode("hello")
+	result = url.pathunescape("hello")
 	testaux.asserteq(result, "hello", "Test 44.2: no encoding unchanged")
 
 	-- UTF-8 multibyte decode
-	result = helper.urldecode("%E4%BD%A0%E5%A5%BD")
+	result = url.pathunescape("%E4%BD%A0%E5%A5%BD")
 	testaux.asserteq(result, "你好", "Test 44.3: UTF-8 decoded")
 
 	-- Empty string
-	result = helper.urldecode("")
+	result = url.pathunescape("")
 	testaux.asserteq(result, "", "Test 44.4: empty string")
 
 	-- Mixed encoded and plain
-	result = helper.urldecode("a%26b%3Dc")
+	result = url.pathunescape("a%26b%3Dc")
 	testaux.asserteq(result, "a&b=c", "Test 44.5: mixed decode")
 
 	-- Lowercase hex
-	result = helper.urldecode("a%2fb")
+	result = url.pathunescape("a%2fb")
 	testaux.asserteq(result, "a/b", "Test 44.6: lowercase hex")
 
 	-- Uppercase hex
-	result = helper.urldecode("a%2Fb")
+	result = url.pathunescape("a%2Fb")
 	testaux.asserteq(result, "a/b", "Test 44.7: uppercase hex")
 
 	-- Trailing percent (not followed by hex)
-	result = helper.urldecode("100%")
+	result = url.pathunescape("100%")
 	testaux.asserteq(result, "100%", "Test 44.8: trailing % unchanged")
 
 	-- Percent followed by non-hex
-	result = helper.urldecode("100%GG")
+	result = url.pathunescape("100%GG")
 	testaux.asserteq(result, "100%GG", "Test 44.9: non-hex after % unchanged")
 
 	-- Decode %25 → %
-	result = helper.urldecode("100%25")
+	result = url.pathunescape("100%25")
 	testaux.asserteq(result, "100%", "Test 44.10: %25 decoded to %")
 
 	-- Multiple consecutive encodings
-	result = helper.urldecode("%20%20%20")
+	result = url.pathunescape("%20%20%20")
 	testaux.asserteq(result, "   ", "Test 44.11: three spaces")
 
 	-- Round-trip with urlencode
 	local original = "a/b@c&d=e f"
-	result = helper.urldecode(helper.urlencode(original))
+	result = url.queryunescape(url.queryescape(original))
 	testaux.asserteq(result, original, "Test 44.12: round-trip")
 end)
 
-testaux.case("Test 45: htmlunescape comprehensive", function()
+case("Test 45: url.resolve comprehensive", function()
+	-- Absolute URL overrides base
+	local u = url.resolve("http://example.com/path", "http://other.com/new")
+	testaux.asserteq(u.scheme, "http", "Test 45.1: absolute scheme")
+	testaux.asserteq(u.host, "other.com", "Test 45.2: absolute host")
+	testaux.asserteq(u.path, "/new", "Test 45.3: absolute path")
+
+	-- Protocol-relative
+	u = url.resolve("http://example.com/path", "//other.com/new")
+	testaux.asserteq(u.scheme, "http", "Test 45.4: proto-rel scheme")
+	testaux.asserteq(u.host, "other.com", "Test 45.5: proto-rel host")
+
+	-- Root-relative
+	u = url.resolve("http://example.com/a/b", "/c/d")
+	testaux.asserteq(u.path, "/c/d", "Test 45.6: root-relative path")
+
+	-- Path-relative
+	u = url.resolve("http://example.com/a/b", "c")
+	testaux.asserteq(u.path, "/a/c", "Test 45.7: path-relative")
+
+	-- Path-relative with directory
+	u = url.resolve("http://example.com/a/b/c", "d")
+	testaux.asserteq(u.path, "/a/b/d", "Test 45.8: path-relative with dir")
+
+	-- Query-only reference
+	u = url.resolve("http://example.com/path?q=1", "?new=2")
+	testaux.asserteq(u.path, "/path?new=2", "Test 45.15: query-only replaces query")
+
+	-- Query-only with fragment in base
+	u = url.resolve("http://example.com/path?q=1#f", "?new=2")
+	testaux.asserteq(u.path, "/path?new=2", "Test 45.16: query-only strips fragment")
+
+	-- Query-only with no query in base
+	u = url.resolve("http://example.com/path", "?new=1")
+	testaux.asserteq(u.path, "/path?new=1", "Test 45.17: query-only adds query")
+
+	-- Fragment-only reference
+	u = url.resolve("http://example.com/path?q=1#old", "#new")
+	testaux.asserteq(u.path, "/path?q=1#new", "Test 45.18: fragment-only replaces fragment")
+
+	-- Fragment-only with no fragment in base
+	u = url.resolve("http://example.com/path", "#frag")
+	testaux.asserteq(u.path, "/path#frag", "Test 45.19: fragment-only adds fragment")
+end)
+
+case("Test 46: htmlunescape comprehensive", function()
 	-- Named entities
-	testaux.asserteq(helper.htmlunescape("&amp;"), "&", "Test 45.1: &amp;")
-	testaux.asserteq(helper.htmlunescape("&lt;"), "<", "Test 45.2: &lt;")
-	testaux.asserteq(helper.htmlunescape("&gt;"), ">", "Test 45.3: &gt;")
-	testaux.asserteq(helper.htmlunescape("&quot;"), '"', "Test 45.4: &quot;")
-	testaux.asserteq(helper.htmlunescape("&nbsp;"), " ", "Test 45.5: &nbsp;")
+	testaux.asserteq(helper.htmlunescape("&amp;"), "&", "Test 46.1: &amp;")
+	testaux.asserteq(helper.htmlunescape("&lt;"), "<", "Test 46.2: &lt;")
+	testaux.asserteq(helper.htmlunescape("&gt;"), ">", "Test 46.3: &gt;")
+	testaux.asserteq(helper.htmlunescape("&quot;"), '"', "Test 46.4: &quot;")
+	testaux.asserteq(helper.htmlunescape("&nbsp;"), " ", "Test 46.5: &nbsp;")
 
 	-- Numeric entities
-	testaux.asserteq(helper.htmlunescape("&#65;"), "A", "Test 45.6: &#65; = A")
-	testaux.asserteq(helper.htmlunescape("&#20320;"), "你", "Test 45.7: &#20320; = 你")
-	testaux.asserteq(helper.htmlunescape("&#48;"), "0", "Test 45.8: &#48; = 0")
+	testaux.asserteq(helper.htmlunescape("&#65;"), "A", "Test 46.6: &#65; = A")
+	testaux.asserteq(helper.htmlunescape("&#20320;"), "你", "Test 46.7: &#20320; = 你")
+	testaux.asserteq(helper.htmlunescape("&#48;"), "0", "Test 46.8: &#48; = 0")
 
 	-- Mixed entities in HTML
 	local result = helper.htmlunescape("&lt;b&gt;Hello &amp; World&lt;/b&gt;")
-	testaux.asserteq(result, "<b>Hello & World</b>", "Test 45.9: mixed HTML")
+	testaux.asserteq(result, "<b>Hello & World</b>", "Test 46.9: mixed HTML")
 
 	-- No entities
-	testaux.asserteq(helper.htmlunescape("hello world"), "hello world", "Test 45.10: no entities")
+	testaux.asserteq(helper.htmlunescape("hello world"), "hello world", "Test 46.10: no entities")
 
 	-- Empty string
-	testaux.asserteq(helper.htmlunescape(""), "", "Test 45.11: empty string")
+	testaux.asserteq(helper.htmlunescape(""), "", "Test 46.11: empty string")
 
 	-- Numeric + named mixed
 	result = helper.htmlunescape("&#60;p&#62;text&amp;more&#60;/p&#62;")
-	testaux.asserteq(result, "<p>text&more</p>", "Test 45.12: numeric and named mixed")
+	testaux.asserteq(result, "<p>text&more</p>", "Test 46.12: numeric and named mixed")
 
 	-- Multiple same entity
 	result = helper.htmlunescape("&amp;&amp;&amp;")
-	testaux.asserteq(result, "&&&", "Test 45.13: repeated entity")
+	testaux.asserteq(result, "&&&", "Test 46.13: repeated entity")
 
 	-- Entity-like but unknown name (should remain unchanged)
 	result = helper.htmlunescape("&unknown;")
-	testaux.asserteq(result, "&unknown;", "Test 45.14: unknown named entity unchanged")
+	testaux.asserteq(result, "&unknown;", "Test 46.14: unknown named entity unchanged")
 end)
 
-testaux.case("Test 46: client.request API - empty body with Content-Length 0 and chunked", function()
+case("Test 47: client.request API - empty body with Content-Length 0 and chunked", function()
 	-- Part 1: Content-Length 0
 	server_handler = function(stream)
-		testaux.asserteq(stream.method, "GET", "Test 46.1: Method should be GET")
+		testaux.asserteq(stream.method, "GET", "Test 47.1: Method should be GET")
 		stream:respond(200, {
 			["content-type"] = "text/plain",
 			["content-length"] = 0,
@@ -1454,21 +1522,21 @@ testaux.case("Test 46: client.request API - empty body with Content-Length 0 and
 	end
 
 	local stream<close>, err = httpc:request("GET", "http://127.0.0.1:8080/empty", {})
-	testaux.assertneq(stream, nil, "Test 46.2: stream should not be nil")
-	testaux.asserteq(err, nil, "Test 46.3: err should be nil")
+	testaux.assertneq(stream, nil, "Test 47.2: stream should not be nil")
+	testaux.asserteq(err, nil, "Test 47.3: err should be nil")
 	stream:closewrite()
 	local ok, wait_err = stream:waitresponse()
-	testaux.asserteq(ok, true, "Test 46.4: waitresponse should succeed")
-	testaux.asserteq(wait_err, nil, "Test 46.5: waitresponse err should be nil")
-	testaux.asserteq(stream.status, 200, "Test 46.6: status should be 200")
+	testaux.asserteq(ok, true, "Test 47.4: waitresponse should succeed")
+	testaux.asserteq(wait_err, nil, "Test 47.5: waitresponse err should be nil")
+	testaux.asserteq(stream.status, 200, "Test 47.6: status should be 200")
 
 	local body, read_err = stream:readall()
-	testaux.asserteq(body, "", "Test 46.7: body should be empty string")
-	testaux.asserteq(read_err, nil, "Test 46.8: err should be nil for empty body")
+	testaux.asserteq(body, "", "Test 47.7: body should be empty string")
+	testaux.asserteq(read_err, nil, "Test 47.8: err should be nil for empty body")
 
 	-- Part 2: Chunked transfer encoding
 	server_handler = function(stream)
-		testaux.asserteq(stream.method, "GET", "Test 46.9: Method should be GET (chunked)")
+		testaux.asserteq(stream.method, "GET", "Test 47.9: Method should be GET (chunked)")
 		stream:respond(200, {
 			["content-type"] = "text/plain",
 			["transfer-encoding"] = "chunked",
@@ -1477,34 +1545,426 @@ testaux.case("Test 46: client.request API - empty body with Content-Length 0 and
 	end
 
 	local stream2<close>, err2 = httpc:request("GET", "http://127.0.0.1:8080/empty_chunked", {})
-	testaux.assertneq(stream2, nil, "Test 46.10: stream should not be nil (chunked)")
-	testaux.asserteq(err2, nil, "Test 46.11: err should be nil (chunked)")
+	testaux.assertneq(stream2, nil, "Test 47.10: stream should not be nil (chunked)")
+	testaux.asserteq(err2, nil, "Test 47.11: err should be nil (chunked)")
 	stream2:closewrite()
 	local ok2, wait_err2 = stream2:waitresponse()
-	testaux.asserteq(ok2, true, "Test 46.12: waitresponse should succeed (chunked)")
-	testaux.asserteq(wait_err2, nil, "Test 46.13: waitresponse err should be nil (chunked)")
-	testaux.asserteq(stream2.status, 200, "Test 46.14: status should be 200 (chunked)")
+	testaux.asserteq(ok2, true, "Test 47.12: waitresponse should succeed (chunked)")
+	testaux.asserteq(wait_err2, nil, "Test 47.13: waitresponse err should be nil (chunked)")
+	testaux.asserteq(stream2.status, 200, "Test 47.14: status should be 200 (chunked)")
 
 	local body2, read_err2 = stream2:readall()
-	testaux.asserteq(body2, "", "Test 46.15: body should be empty string (chunked)")
-	testaux.asserteq(read_err2, nil, "Test 46.16: err should be nil for empty chunked body")
+	testaux.asserteq(body2, "", "Test 47.15: body should be empty string (chunked)")
+	testaux.asserteq(read_err2, nil, "Test 47.16: err should be nil for empty chunked body")
 	wait_done()
 end)
 
-testaux.case("Test 47: HTTP DNS failure returns contextual string", function()
+case("Test 48: HTTP DNS failure returns contextual string", function()
 	testaux.with_mocked_dns(function(host, qtype)
 		return nil, "Query timed out (10001)"
 	end, {"silly.net.http.client", "silly.net.http"}, function(reloaded)
 		local mock_http = reloaded["silly.net.http"]
 		local stream, err = mock_http.request("GET", "http://dns-fail.test:8080", {})
-		testaux.asserteq(stream, nil, "Test 47.1: HTTP request should fail on DNS error")
+		testaux.asserteq(stream, nil, "Test 48.1: HTTP request should fail on DNS error")
 		testaux.assertcontains(err, "dns lookup",
-			"Test 47.2: Error should mention dns lookup")
+			"Test 48.2: Error should mention dns lookup")
 		testaux.assertcontains(err, "dns-fail.test",
-			"Test 47.3: Error should include the failing host")
+			"Test 48.3: Error should include the failing host")
 		testaux.assertcontains(err, "timed out",
-			"Test 47.4: Error should propagate underlying DNS reason")
+			"Test 48.4: Error should propagate underlying DNS reason")
 	end)
+end)
+
+case("Test 49: Host header not duplicated and user header preserved", function()
+	local received_host
+	server_handler = function(stream)
+		received_host = stream.header["host"]
+		stream:respond(200, { ["content-length"] = 2 })
+		stream:write("OK")
+	end
+
+	local hdr = { ["host"] = "my-custom-host", ["x-test"] = "value" }
+	local stream<close>, err = httpc:request("GET", "http://127.0.0.1:8080/host-test", hdr)
+	testaux.assertneq(stream, nil, "Test 49.1: request should succeed")
+	stream:closewrite()
+	local body = stream:readall()
+	testaux.asserteq(body, "OK", "Test 49.2: body should be OK")
+
+	-- user header table must not be modified
+	testaux.asserteq(hdr["host"], "my-custom-host", "Test 49.3: user header[\"host\"] should be preserved")
+	testaux.asserteq(hdr["x-test"], "value", "Test 49.4: user header[\"x-test\"] should be preserved")
+
+	-- server receives the host from the URL (authority), not from user header["host"]
+	testaux.asserteq(received_host, "127.0.0.1:8080", "Test 49.5: server host should be URL authority")
+
+	wait_done()
+end)
+
+-- Redirect tests use set_nil = false so the handler persists across
+-- multiple requests (redirect + follow). httpc:get/post are fully
+-- synchronous, so no wait_done() is needed — by the time the call
+-- returns, the server has handled all requests in the chain.
+
+case("Test 50: 301 redirect changes POST to GET and drops body", function()
+	set_nil = false
+	local methods = {}
+	server_handler = function(stream)
+		methods[#methods + 1] = stream.method
+		if stream.path == "/redirect" then
+			stream:readall()
+			stream:respond(301, { ["location"] = "/target" })
+		else
+			stream:respond(200, {
+				["content-type"] = "text/plain",
+				["content-length"] = 2,
+			})
+			stream:write("OK")
+		end
+	end
+	local response = httpc:post("http://127.0.0.1:8080/redirect", {
+		["content-type"] = "text/plain"
+	}, "request-body")
+	testaux.assertneq(response, nil, "Test 50.1: redirect should succeed")
+	testaux.asserteq(response.status, 200, "Test 50.2: final status should be 200")
+	testaux.asserteq(response.body, "OK", "Test 50.3: body should be OK")
+	testaux.asserteq(methods[1], "POST", "Test 50.4: first request should be POST")
+	testaux.asserteq(methods[2], "GET", "Test 50.5: redirect should change method to GET")
+end)
+
+case("Test 51: 307 redirect preserves POST method and body", function()
+	set_nil = false
+	local target_method
+	local target_body
+	server_handler = function(stream)
+		if stream.path == "/redirect" then
+			stream:readall()
+			stream:respond(307, { ["location"] = "/target" })
+		else
+			target_method = stream.method
+			target_body = stream:readall()
+			stream:respond(200, {
+				["content-type"] = "text/plain",
+				["content-length"] = 2,
+			})
+			stream:write("OK")
+		end
+	end
+	local response = httpc:post("http://127.0.0.1:8080/redirect", {
+		["content-type"] = "text/plain"
+	}, "preserved-body")
+	testaux.assertneq(response, nil, "Test 51.1: redirect should succeed")
+	testaux.asserteq(response.status, 200, "Test 51.2: final status should be 200")
+	testaux.asserteq(target_method, "POST", "Test 51.3: method should be preserved as POST")
+	testaux.asserteq(target_body, "preserved-body", "Test 51.4: body should be preserved")
+end)
+
+case("Test 52: Redirect loop detection", function()
+	set_nil = false
+	server_handler = function(stream)
+		stream:respond(301, { ["location"] = "/loop" })
+	end
+	local response, err = httpc:get("http://127.0.0.1:8080/loop")
+	testaux.asserteq(response, nil, "Test 52.1: loop should fail")
+	testaux.assertneq(err, nil, "Test 52.2: should return error")
+	testaux.assertneq(err:find("redirect loop"), nil, "Test 52.3: error should mention redirect loop")
+end)
+
+case("Test 53: Too many redirects", function()
+	set_nil = false
+	server_handler = function(stream)
+		local n = stream.path:match("/r(%d+)")
+		n = tonumber(n) or 0
+		stream:respond(301, { ["location"] = "/r" .. (n + 1) })
+	end
+	local response, err = httpc:get("http://127.0.0.1:8080/r0")
+	testaux.asserteq(response, nil, "Test 53.1: should fail on too many redirects")
+	testaux.assertneq(err, nil, "Test 53.2: should return error")
+	testaux.asserteq(err, "too many redirects", "Test 53.3: error should be 'too many redirects'")
+end)
+
+case("Test 54: 303 redirect changes POST to GET", function()
+	set_nil = false
+	local methods = {}
+	server_handler = function(stream)
+		methods[#methods + 1] = stream.method
+		if stream.path == "/redirect" then
+			stream:readall()
+			stream:respond(303, { ["location"] = "/target" })
+		else
+			stream:respond(200, {
+				["content-type"] = "text/plain",
+				["content-length"] = 2,
+			})
+			stream:write("OK")
+		end
+	end
+	local response = httpc:post("http://127.0.0.1:8080/redirect", {
+		["content-type"] = "text/plain"
+	}, "post-data")
+	testaux.assertneq(response, nil, "Test 54.1: redirect should succeed")
+	testaux.asserteq(response.status, 200, "Test 54.2: final status should be 200")
+	testaux.asserteq(methods[1], "POST", "Test 54.3: first request should be POST")
+	testaux.asserteq(methods[2], "GET", "Test 54.4: 303 should change method to GET")
+end)
+
+case("Test 55: 308 redirect preserves POST method and body", function()
+	set_nil = false
+	local target_method
+	local target_body
+	server_handler = function(stream)
+		if stream.path == "/redirect" then
+			stream:readall()
+			stream:respond(308, { ["location"] = "/target" })
+		else
+			target_method = stream.method
+			target_body = stream:readall()
+			stream:respond(200, {
+				["content-type"] = "text/plain",
+				["content-length"] = 2,
+			})
+			stream:write("OK")
+		end
+	end
+	local response = httpc:post("http://127.0.0.1:8080/redirect", {
+		["content-type"] = "text/plain"
+	}, "308-body")
+	testaux.assertneq(response, nil, "Test 55.1: redirect should succeed")
+	testaux.asserteq(response.status, 200, "Test 55.2: final status should be 200")
+	testaux.asserteq(target_method, "POST", "Test 55.3: method should be preserved as POST")
+	testaux.asserteq(target_body, "308-body", "Test 55.4: body should be preserved")
+end)
+
+case("Test 56: Relative Location URL redirect", function()
+	set_nil = false
+	server_handler = function(stream)
+		if stream.path == "/dir/redirect" then
+			stream:respond(302, { ["location"] = "target" })
+		else
+			stream:respond(200, {
+				["content-type"] = "text/plain",
+				["content-length"] = 5,
+			})
+			stream:write("Hello")
+		end
+	end
+	local response = httpc:get("http://127.0.0.1:8080/dir/redirect")
+	testaux.assertneq(response, nil, "Test 56.1: relative redirect should succeed")
+	testaux.asserteq(response.status, 200, "Test 56.2: final status should be 200")
+	testaux.asserteq(response.body, "Hello", "Test 56.3: body should be Hello")
+end)
+
+case("Test 57: GET redirect with gzip response", function()
+	local original_data = "Compressed redirect data that is long enough for gzip to work with. " ..
+		"Adding more text to improve compression ratio for the test."
+	local compressed = gzip.compress(original_data)
+	testaux.assertneq(compressed, nil, "Test 57.1: gzip.compress should succeed")
+	set_nil = false
+	server_handler = function(stream)
+		if stream.path == "/redirect" then
+			stream:respond(301, { ["location"] = "/target" })
+		else
+			stream:respond(200, {
+				["content-type"] = "text/plain",
+				["content-encoding"] = "gzip",
+				["content-length"] = #compressed,
+			})
+			stream:write(compressed)
+		end
+	end
+	local response = httpc:get("http://127.0.0.1:8080/redirect")
+	testaux.assertneq(response, nil, "Test 57.2: redirect with gzip should succeed")
+	testaux.asserteq(response.status, 200, "Test 57.3: final status should be 200")
+	testaux.asserteq(response.body, original_data, "Test 57.4: body should be decompressed")
+end)
+
+case("Test 58: Cross-host redirect resolves new authority", function()
+	set_nil = false
+	server_handler = function(stream)
+		if stream.path == "/redirect" then
+			stream:respond(301, { ["location"] = "http://localhost:8080/target" })
+		else
+			stream:respond(200, {
+				["content-type"] = "text/plain",
+				["content-length"] = 4,
+			})
+			stream:write("host")
+		end
+	end
+	local response = httpc:get("http://127.0.0.1:8080/redirect")
+	testaux.assertneq(response, nil, "Test 58.1: cross-host redirect should succeed")
+	testaux.asserteq(response.status, 200, "Test 58.2: final status should be 200")
+	testaux.asserteq(response.body, "host", "Test 58.3: body should be host")
+end)
+
+case("Test 58b: Cross-host redirect strips sensitive headers", function()
+	set_nil = false
+	local received_auth
+	server_handler = function(stream)
+		if stream.path == "/redirect" then
+			stream:respond(301, {
+				["location"] = "http://localhost:8080/target",
+				["content-length"] = 0,
+			})
+		else
+			received_auth = stream.header["authorization"]
+			stream:respond(200, {
+				["content-type"] = "text/plain",
+				["content-length"] = 2,
+			})
+			stream:write("ok")
+		end
+	end
+	local response = httpc:get("http://127.0.0.1:8080/redirect", {
+		["authorization"] = "Bearer secret",
+	})
+	testaux.assertneq(response, nil, "Test 58b.1: cross-host redirect should succeed")
+	testaux.asserteq(response.status, 200, "Test 58b.2: final status should be 200")
+	testaux.asserteq(received_auth, nil, "Test 58b.3: Authorization header should be stripped on cross-host redirect")
+end)
+
+case("Test 59: Redirect preserves query string in Location", function()
+	set_nil = false
+	local received_query
+	server_handler = function(stream)
+		if stream.path == "/redirect" then
+			stream:respond(302, { ["location"] = "/target?foo=bar&baz=1" })
+		else
+			received_query = stream.query
+			stream:respond(200, {
+				["content-type"] = "text/plain",
+				["content-length"] = 2,
+			})
+			stream:write("OK")
+		end
+	end
+	local response = httpc:get("http://127.0.0.1:8080/redirect?original=1")
+	testaux.assertneq(response, nil, "Test 59.1: query redirect should succeed")
+	testaux.asserteq(response.status, 200, "Test 59.2: final status should be 200")
+	testaux.asserteq(received_query["foo"], "bar", "Test 59.3: target query foo should be present")
+	testaux.asserteq(received_query["baz"], "1", "Test 59.4: target query baz should be present")
+	testaux.asserteq(received_query["original"], nil, "Test 59.5: original query should not leak")
+end)
+
+case("Test 60: parsequery last-value-wins for duplicate keys", function()
+	local url = require "silly.net.http.url"
+	local q = url.parsequery("a=1&a=2&a=3")
+	testaux.asserteq(q["a"], "3", "Test 60.1: duplicate keys should use last value")
+end)
+
+case("Test 60b: parsequery handles empty values and bare keys", function()
+	local url = require "silly.net.http.url"
+	local q = url.parsequery("a=1&b=&c")
+	testaux.asserteq(q["a"], "1", "Test 60b.1: normal key=value")
+	testaux.asserteq(q["b"], "", "Test 60b.2: empty value (key=)")
+	testaux.asserteq(q["c"], "", "Test 60b.3: bare key without =")
+end)
+
+case("Test 61: Redirect with no Location header returns response as-is", function()
+	server_handler = function(stream)
+		stream:respond(302, { ["content-length"] = 8 })
+		stream:write("no-loc!!")
+	end
+	local response = httpc:get("http://127.0.0.1:8080")
+	testaux.assertneq(response, nil, "Test 61.1: should return response")
+	testaux.asserteq(response.status, 302, "Test 61.2: status should be 302")
+	testaux.asserteq(response.body, "no-loc!!", "Test 61.3: body should be returned")
+	wait_done()
+end)
+
+case("Test 62: readall() with deadline timeout", function()
+	server_handler = function(stream)
+		stream:respond(200, {
+			["content-length"] = 20,
+		})
+		stream:write("12345")
+		stream:flush()
+		time.sleep(500)  -- delay longer than client timeout
+	end
+
+	local stream<close>, err = httpc:request("GET", "http://127.0.0.1:8080", {})
+	testaux.assertneq(stream, nil, "Test 62.1: Request should succeed")
+	stream:closewrite()
+
+	local body, err = stream:readall(50)
+	testaux.asserteq(body, nil, "Test 62.2: readall should return nil on timeout")
+	testaux.asserteq(err, ETIMEDOUT, "Test 62.3: err should be ETIMEDOUT")
+
+	-- subsequent readall should fail immediately with cached error
+	local body2, err2 = stream:readall()
+	testaux.asserteq(body2, nil, "Test 62.4: second readall should return nil")
+	testaux.asserteq(err2, ETIMEDOUT, "Test 62.5: second readall should return cached ETIMEDOUT")
+
+	wait_done()
+end)
+
+case("Test 63: timed-out connection is not reused by pool", function()
+	local c = http.newclient({
+		max_idle_per_host = 10,
+		idle_timeout = 2000,
+	})
+
+	-- First request: server writes partial response, client times out
+	server_handler = function(stream)
+		stream:respond(200, {
+			["content-length"] = 20,
+		})
+		stream:write("12345")
+		stream:flush()
+		time.sleep(500)
+	end
+
+	local stream<close>, err = c:request("GET", "http://127.0.0.1:8080", {})
+	testaux.assertneq(stream, nil, "Test 63.1: First request should succeed")
+	stream:closewrite()
+
+	local body, err = stream:readall(50)
+	testaux.asserteq(body, nil, "Test 63.2: readall should timeout")
+	testaux.asserteq(err, ETIMEDOUT, "Test 63.3: err should be ETIMEDOUT")
+
+	wait_done()
+
+	-- Second request: should succeed on a NEW connection (not the broken one)
+	server_handler = function(stream)
+		stream:respond(200, {
+			["content-type"] = "text/plain",
+			["content-length"] = 2,
+		})
+		stream:write("OK")
+	end
+
+	local stream2<close>, err2 = c:request("GET", "http://127.0.0.1:8080", {})
+	testaux.assertneq(stream2, nil, "Test 63.4: Second request should succeed")
+	stream2:closewrite()
+
+	local body2, err2 = stream2:readall()
+	testaux.asserteq(body2, "OK", "Test 63.5: Second response body should be OK")
+	testaux.asserteq(stream2.status, 200, "Test 63.6: Second status should be 200")
+
+	wait_done()
+end)
+
+case("Test 64: Expect 100-continue rejected by server", function()
+	server_handler = function(stream)
+		stream:respond(417, {
+			["content-type"] = "text/plain",
+			["content-length"] = 18,
+		})
+		stream:write("Expectation Failed")
+	end
+
+	local stream<close>, err = httpc:request("POST", "http://127.0.0.1:8080", {
+		["expect"] = "100-continue",
+		["content-length"] = 4,
+	})
+	testaux.assertneq(stream, nil, "Test 64.1: request should succeed")
+
+	stream:closewrite("body")
+	testaux.asserteq(stream.status, 417, "Test 64.2: status should be 417")
+
+	local body, err = stream:readall()
+	testaux.asserteq(body, "Expectation Failed", "Test 64.3: body should be readable")
+
+	wait_done()
 end)
 
 if server then

--- a/test/testhttp2.lua
+++ b/test/testhttp2.lua
@@ -55,11 +55,20 @@ local function wait_done()
 	end
 end
 
-testaux.case("Test 1: Basic HTTP/2 Server Setup", function()
+local function case(name, fn)
+	testaux.case(name, function()
+		local ok, err = pcall(fn)
+		server_handler = nil
+		set_nil = true
+		if not ok then error(err) end
+	end)
+end
+
+case("Test 1: Basic HTTP/2 Server Setup", function()
 	testaux.asserteq(not not server, true, "Server should start successfully")
 end)
 
-testaux.case("Test 2: HTTP/2 Chunked Transfer", function()
+case("Test 2: HTTP/2 Chunked Transfer", function()
 	server_handler = function(stream)
 		print("Test 2")
 		testaux.asserteq(stream.version, "HTTP/2", "Test 2.1: Should be HTTP/2")
@@ -76,7 +85,7 @@ testaux.case("Test 2: HTTP/2 Chunked Transfer", function()
 	wait_done()
 end)
 
-testaux.case("Test 3: HTTP/2 Content-Length and Request Body", function()
+case("Test 3: HTTP/2 Content-Length and Request Body", function()
 	server_handler = function(stream)
 		local body, err = stream:readall()
 		testaux.asserteq(body, "Hello Server", "Test 3.1: Server should receive request body")
@@ -94,7 +103,7 @@ testaux.case("Test 3: HTTP/2 Content-Length and Request Body", function()
 	wait_done()
 end)
 
-testaux.case("Test 4: HTTP/2 Query Parameters", function()
+case("Test 4: HTTP/2 Query Parameters", function()
 	server_handler = function(stream)
 		local query = stream.query
 		testaux.asserteq(query["name"], "test", "Test 4.1: Server should receive query parameters")
@@ -111,7 +120,7 @@ testaux.case("Test 4: HTTP/2 Query Parameters", function()
 	wait_done()
 end)
 
-testaux.case("Test 5: HTTP/2 Status Codes", function()
+case("Test 5: HTTP/2 Status Codes", function()
 	local status_codes = {
 		[200] = "OK",
 		[201] = "Created",
@@ -148,7 +157,7 @@ testaux.case("Test 5: HTTP/2 Status Codes", function()
 	end
 end)
 
-testaux.case("Test 6: HTTP/2 Headers Processing", function()
+case("Test 6: HTTP/2 Headers Processing", function()
 	server_handler = function(stream)
 		local user_agent = stream.header["user-agent"] or ""
 		local accept = stream.header["accept"] or ""
@@ -190,7 +199,7 @@ testaux.case("Test 6: HTTP/2 Headers Processing", function()
 	wait_done()
 end)
 
-testaux.case("Test 7: Content-Type and Accept Headers", function()
+case("Test 7: Content-Type and Accept Headers", function()
 	local function x(stream)
 		local accept = stream.header["accept"] or "*/*"
 		if accept:find("application/json", 1, true) then
@@ -229,7 +238,7 @@ testaux.case("Test 7: Content-Type and Accept Headers", function()
 	wait_done()
 end)
 
-testaux.case("Test 8: client.request API - Basic GET", function()
+case("Test 8: client.request API - Basic GET", function()
 	server_handler = function(stream)
 		testaux.asserteq(stream.method, "GET", "Test 8.1: Method should be GET")
 		testaux.asserteq(stream.path, "/api/test", "Test 8.2: Path should be /api/test")
@@ -252,7 +261,7 @@ testaux.case("Test 8: client.request API - Basic GET", function()
 	wait_done()
 end)
 
-testaux.case("Test 9: client.request API - POST with body", function()
+case("Test 9: client.request API - POST with body", function()
 	server_handler = function(stream)
 		testaux.asserteq(stream.method, "POST", "Test 9.1: Method should be POST")
 		local body, err = stream:readall()
@@ -278,7 +287,7 @@ testaux.case("Test 9: client.request API - POST with body", function()
 	wait_done()
 end)
 
-testaux.case("Test 10: client.request API - Multiple writes", function()
+case("Test 10: client.request API - Multiple writes", function()
 	server_handler = function(stream)
 		local body, err = stream:readall()
 		testaux.asserteq(body, "part1part2part3", "Test 10.1: body should be concatenated")
@@ -299,7 +308,7 @@ testaux.case("Test 10: client.request API - Multiple writes", function()
 	wait_done()
 end)
 
-testaux.case("Test 11: client.request API - HEAD request", function()
+case("Test 11: client.request API - HEAD request", function()
 	server_handler = function(stream)
 		testaux.asserteq(stream.method, "HEAD", "Test 11.1: Method should be HEAD")
 		stream:respond(200, {
@@ -320,7 +329,7 @@ testaux.case("Test 11: client.request API - HEAD request", function()
 	wait_done()
 end)
 
-testaux.case("Test 12: Trailer headers with chunked", function()
+case("Test 12: Trailer headers with chunked", function()
 	server_handler = function(stream)
 		stream:respond(200, {
 			["content-type"] = "text/plain",
@@ -346,7 +355,7 @@ testaux.case("Test 12: Trailer headers with chunked", function()
 	wait_done()
 end)
 
-testaux.case("Test 13: stream:read(n) - partial reads with small data", function()
+case("Test 13: stream:read(n) - partial reads with small data", function()
 	server_handler = function(stream)
 		stream:respond(200, {
 			["content-type"] = "text/plain",
@@ -380,7 +389,7 @@ testaux.case("Test 13: stream:read(n) - partial reads with small data", function
 	wait_done()
 end)
 
-testaux.case("Test 14: stream:read(n) - partial reads with multiple writes", function()
+case("Test 14: stream:read(n) - partial reads with multiple writes", function()
 	server_handler = function(stream)
 		stream:respond(200, {})
 		stream:write("AAAAA")  -- 5 bytes
@@ -424,7 +433,7 @@ testaux.case("Test 14: stream:read(n) - partial reads with multiple writes", fun
 	wait_done()
 end)
 
-testaux.case("Test 15: stream:read(n) - read more than available", function()
+case("Test 15: stream:read(n) - read more than available", function()
 	server_handler = function(stream)
 		stream:respond(200, {
 			["content-type"] = "text/plain",
@@ -449,7 +458,7 @@ testaux.case("Test 15: stream:read(n) - read more than available", function()
 	wait_done()
 end)
 
-testaux.case("Test 16: Flow control - Stream window 63KB single stream", function()
+case("Test 16: Flow control - Stream window 63KB single stream", function()
 	local ch = channel.new()
 	local data = crypto.randomkey(63 * 1024)
 	server_handler = function(stream)
@@ -482,7 +491,7 @@ testaux.case("Test 16: Flow control - Stream window 63KB single stream", functio
 	wait_done()
 end)
 
-testaux.case("Test 17: Flow control - Connection window with concurrent streams", function()
+case("Test 17: Flow control - Connection window with concurrent streams", function()
 	-- Test that connection window is shared between streams
 	-- Stream 1 sends 1M-1KB, then Stream 2 sends 1M-1KB
 	-- This should exhaust connection window and require flow control
@@ -566,7 +575,7 @@ testaux.case("Test 17: Flow control - Connection window with concurrent streams"
 	wait_done()
 end)
 
-testaux.case("Test 18: Flow control - Window recovery after read", function()
+case("Test 18: Flow control - Window recovery after read", function()
 	-- Test that reading data sends WINDOW_UPDATE and recovers window
 	local data = crypto.randomkey(66 * 1024)
 
@@ -596,7 +605,7 @@ testaux.case("Test 18: Flow control - Window recovery after read", function()
 	wait_done()
 end)
 
-testaux.case("Test 19: Connection reuse - Multiple requests on same channel", function()
+case("Test 19: Connection reuse - Multiple requests on same channel", function()
 	-- Test that multiple requests reuse the same HTTP/2 connection
 
 	for i = 1, 5 do
@@ -620,7 +629,7 @@ testaux.case("Test 19: Connection reuse - Multiple requests on same channel", fu
 	testaux.asserteq(h2_count, 1, "Test 19.6: Should have exactly 1 HTTP/2 connection")
 end)
 
-testaux.case("Test 20: Connection broken during read", function()
+case("Test 20: Connection broken during read", function()
 	server_handler = function(stream)
 		stream:respond(200, {})
 		stream:write("partial")
@@ -641,7 +650,7 @@ testaux.case("Test 20: Connection broken during read", function()
 	server_handler = nil
 end)
 
-testaux.case("Test 21: HTTP/2 GET with gzip compression", function()
+case("Test 21: HTTP/2 GET with gzip compression", function()
 	local original_data = "Hello HTTP/2 World! This is a test data that should be compressed with gzip. " ..
 		"The more data we have, the better compression ratio we get. " ..
 		"HTTP/2 supports gzip compression transparently."
@@ -668,7 +677,7 @@ testaux.case("Test 21: HTTP/2 GET with gzip compression", function()
 	wait_done()
 end)
 
-testaux.case("Test 22: HTTP/2 POST with gzip compression response", function()
+case("Test 22: HTTP/2 POST with gzip compression response", function()
 	local request_data = "Request from HTTP/2 client"
 	local response_data = "This is a compressed HTTP/2 response from server. " ..
 		"Adding more text to make compression more effective with HTTP/2."
@@ -698,7 +707,7 @@ testaux.case("Test 22: HTTP/2 POST with gzip compression response", function()
 	wait_done()
 end)
 
-testaux.case("Test 23: HTTP/2 GET without gzip (no Content-Encoding)", function()
+case("Test 23: HTTP/2 GET without gzip (no Content-Encoding)", function()
 	local original_data = "Uncompressed HTTP/2 data"
 
 	server_handler = function(stream)
@@ -715,7 +724,7 @@ testaux.case("Test 23: HTTP/2 GET without gzip (no Content-Encoding)", function(
 	wait_done()
 end)
 
-testaux.case("Test 24: HTTP/2 GET with Accept-Encoding header check", function()
+case("Test 24: HTTP/2 GET with Accept-Encoding header check", function()
 	server_handler = function(stream)
 		local accept_encoding = stream.header["accept-encoding"]
 		testaux.asserteq(accept_encoding, "gzip", "Test 24.1: Client should send Accept-Encoding: gzip")
@@ -731,7 +740,7 @@ testaux.case("Test 24: HTTP/2 GET with Accept-Encoding header check", function()
 	wait_done()
 end)
 
-testaux.case("Test 25: HTTP/2 cocurrent stream stream", function()
+case("Test 25: HTTP/2 cocurrent stream stream", function()
 	local x = function(stream)
 		stream:respond(200, {
 			["content-type"] = "text/plain",
@@ -785,7 +794,7 @@ testaux.case("Test 25: HTTP/2 cocurrent stream stream", function()
 	s:close()
 end)
 
-testaux.case("Test 26: HTTP/2 opensream on a closed channel", function()
+case("Test 26: HTTP/2 opensream on a closed channel", function()
 	local x = function(stream)
 		stream:respond(200, {
 			["content-type"] = "text/plain",
@@ -812,7 +821,7 @@ testaux.case("Test 26: HTTP/2 opensream on a closed channel", function()
 	testaux.asserteq(err, "Channel goaway", "Test 26.5: Openstream should fail")
 end)
 
-testaux.case("Test 27: HTTP/2 streamcount accuracy with concurrent open/close", function()
+case("Test 27: HTTP/2 streamcount accuracy with concurrent open/close", function()
 	local x = function(stream)
 		stream:respond(200, {
 			["content-type"] = "text/plain",
@@ -945,7 +954,7 @@ end)
 -- Bug: When stream1 calls request() (hpack_pack adds headers to dynamic table),
 -- then stream2 uses IDENTICAL headers (HPACK encodes as indexed reference),
 -- if stream2 sends first, the server's decoder fails (dynamic table entry doesn't exist)
-testaux.case("Test 28: HPACK encoder state corruption", function()
+case("Test 28: HPACK encoder state corruption", function()
 	set_nil = false
 	server_handler = function(stream)
 		-- Return received headers as JSON in body for verification
@@ -1036,7 +1045,7 @@ end)
 -- Bug: If stream.request() sets localstate=STATE_HEADER, then close() would send RST_STREAM
 -- even though no HEADERS frame was sent yet (stream is still IDLE).
 -- According to HTTP/2 spec, sending RST_STREAM in IDLE state causes PROTOCOL_ERROR.
-testaux.case("Test 29: Stream close in IDLE state (no data sent)", function()
+case("Test 29: Stream close in IDLE state (no data sent)", function()
 	set_nil = false
 	local sync_ch = channel.new()
 	local call_count = 0
@@ -1097,6 +1106,158 @@ testaux.case("Test 29: Stream close in IDLE state (no data sent)", function()
 
 	ch:close()
 	set_nil = true
+end)
+
+case("Test 30: Host header not duplicated and user header preserved", function()
+	local received_host
+	server_handler = function(stream)
+		received_host = stream.header["host"]
+		stream:respond(200, { ["content-length"] = 2 })
+		stream:write("OK")
+	end
+
+	local hdr = { ["host"] = "my-custom-host", ["x-test"] = "value" }
+	local stream<close>, err = httpc:request("GET", "https://127.0.0.1:8082/host-test", hdr)
+	testaux.assertneq(stream, nil, "Test 30.1: request should succeed")
+	stream:closewrite()
+	local body = stream:readall()
+	testaux.asserteq(body, "OK", "Test 30.2: body should be OK")
+
+	-- user header table must not be modified
+	testaux.asserteq(hdr["host"], "my-custom-host", "Test 30.3: user header[\"host\"] should be preserved")
+	testaux.asserteq(hdr["x-test"], "value", "Test 30.4: user header[\"x-test\"] should be preserved")
+
+	-- server should NOT see host (h2 uses :authority pseudo-header)
+	testaux.asserteq(received_host, nil, "Test 30.5: server should not receive host header in h2")
+
+	wait_done()
+end)
+
+-- Redirect tests for HTTP/2
+
+case("Test 31: h2 301 redirect changes POST to GET and drops body", function()
+	set_nil = false
+	local methods = {}
+	server_handler = function(stream)
+		methods[#methods + 1] = stream.method
+		if stream.path == "/redirect" then
+			stream:readall()
+			stream:respond(301, { ["location"] = "/target" })
+		else
+			stream:respond(200, {
+				["content-type"] = "text/plain",
+			})
+			stream:closewrite("OK")
+		end
+	end
+	local response = httpc:post("https://127.0.0.1:8082/redirect", {
+		["content-type"] = "text/plain"
+	}, "request-body")
+	testaux.assertneq(response, nil, "Test 31.1: redirect should succeed")
+	testaux.asserteq(response.status, 200, "Test 31.2: final status should be 200")
+	testaux.asserteq(response.body, "OK", "Test 31.3: body should be OK")
+	testaux.asserteq(methods[1], "POST", "Test 31.4: first request should be POST")
+	testaux.asserteq(methods[2], "GET", "Test 31.5: redirect should change method to GET")
+end)
+
+case("Test 32: h2 307 redirect preserves POST method and body", function()
+	set_nil = false
+	local target_method
+	local target_body
+	server_handler = function(stream)
+		if stream.path == "/redirect" then
+			stream:readall()
+			stream:respond(307, { ["location"] = "/target" })
+		else
+			target_method = stream.method
+			target_body = stream:readall()
+			stream:respond(200, {
+				["content-type"] = "text/plain",
+			})
+			stream:closewrite("OK")
+		end
+	end
+	local response = httpc:post("https://127.0.0.1:8082/redirect", {
+		["content-type"] = "text/plain"
+	}, "preserved-body")
+	testaux.assertneq(response, nil, "Test 32.1: redirect should succeed")
+	testaux.asserteq(response.status, 200, "Test 32.2: final status should be 200")
+	testaux.asserteq(target_method, "POST", "Test 32.3: method should be preserved as POST")
+	testaux.asserteq(target_body, "preserved-body", "Test 32.4: body should be preserved")
+end)
+
+case("Test 33: h2 redirect loop detection", function()
+	set_nil = false
+	server_handler = function(stream)
+		stream:respond(301, { ["location"] = "/loop" })
+	end
+	local response, err = httpc:get("https://127.0.0.1:8082/loop")
+	testaux.asserteq(response, nil, "Test 33.1: loop should fail")
+	testaux.assertneq(err, nil, "Test 33.2: should return error")
+	testaux.assertneq(err:find("redirect loop"), nil, "Test 33.3: error should mention redirect loop")
+end)
+
+case("Test 34: h2 redirect with gzip response", function()
+	local original_data = "Compressed h2 redirect data that should be long enough for gzip. " ..
+		"Adding more text to improve compression ratio for this test."
+	local compressed = gzip.compress(original_data)
+	testaux.assertneq(compressed, nil, "Test 34.1: gzip.compress should succeed")
+	set_nil = false
+	server_handler = function(stream)
+		if stream.path == "/redirect" then
+			stream:respond(301, { ["location"] = "/target" })
+		else
+			stream:respond(200, {
+				["content-type"] = "text/plain",
+				["content-encoding"] = "gzip",
+			})
+			stream:closewrite(compressed)
+		end
+	end
+	local response = httpc:get("https://127.0.0.1:8082/redirect")
+	testaux.assertneq(response, nil, "Test 34.2: redirect with gzip should succeed")
+	testaux.asserteq(response.status, 200, "Test 34.3: final status should be 200")
+	testaux.asserteq(response.body, original_data, "Test 34.4: body should be decompressed")
+end)
+
+case("Test 35: h2 cross-host redirect resolves new authority", function()
+	set_nil = false
+	server_handler = function(stream)
+		if stream.path == "/redirect" then
+			stream:respond(301, { ["location"] = "https://localhost:8082/target" })
+		else
+			stream:respond(200, {
+				["content-type"] = "text/plain",
+			})
+			stream:closewrite("host")
+		end
+	end
+	local response = httpc:get("https://127.0.0.1:8082/redirect")
+	testaux.assertneq(response, nil, "Test 35.1: cross-host redirect should succeed")
+	testaux.asserteq(response.status, 200, "Test 35.2: final status should be 200")
+	testaux.asserteq(response.body, "host", "Test 35.3: body should be host")
+end)
+
+case("Test 36: h2 redirect preserves query string in Location", function()
+	set_nil = false
+	local received_query
+	server_handler = function(stream)
+		if stream.path == "/redirect" then
+			stream:respond(302, { ["location"] = "/target?foo=bar&baz=1" })
+		else
+			received_query = stream.query
+			stream:respond(200, {
+				["content-type"] = "text/plain",
+			})
+			stream:closewrite("OK")
+		end
+	end
+	local response = httpc:get("https://127.0.0.1:8082/redirect?original=1")
+	testaux.assertneq(response, nil, "Test 36.1: query redirect should succeed")
+	testaux.asserteq(response.status, 200, "Test 36.2: final status should be 200")
+	testaux.asserteq(received_query["foo"], "bar", "Test 36.3: target query foo should be present")
+	testaux.asserteq(received_query["baz"], "1", "Test 36.4: target query baz should be present")
+	testaux.asserteq(received_query["original"], nil, "Test 36.5: original query should not leak")
 end)
 
 time.sleep(2000)


### PR DESCRIPTION
- Extract URL parsing/encoding from helper into net.http.url module
- Implement HTTP redirect following (301/302/303/307/308) with loop detection
- Add client.close() to gracefully shut down pooled connections
- Fix host header duplication: h1/h2 now inject Host/:authority from URL authority without modifying the user's header table
- Add tests for host header deduplication in h1 and h2