### PR TITLE
cluster: simplify protocol and harden response handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,14 @@
 - h1 and h2 now inject the Host/`:authority` header from the URL authority instead of the user-supplied header table; the user's header table is never modified.
 - h1 `request()` accepts an optional `timeout` parameter for `Expect: 100-continue` wait.
 - h1 client `read`/`readall` use a single deadline timer instead of passing timeout to each internal `conn:read`, eliminating timeout amplification across chunked/content-length reads.
-- `cluster.connect` no longer caches peers by address; connecting to the same address now creates independent connections (for load balancing scenarios). It is now lazy (the TCP connection is established on the first `call`/`send`) and its return signature changed from `peer?, err?` to `peer` — errors are surfaced at call time instead.
+- `cluster.connect` is now eager: DNS resolution and TCP connect happen immediately (yields, must be called in a coroutine). Return signature changed to `peer?, err?`. Connecting to the same address creates independent connections.
+- Auto-reconnect removed. When a connection drops, `call`/`send` returns `nil, "Peer closed"`. Call `cluster.connect()` again to obtain a new peer.
 - `accept` callback signature changed from `function(peer, addr)` to `function(peer)`; client address available via `peer.remoteaddr`.
-- Peer objects now have `remoteaddr` field (set for both incoming and outgoing connections); `addr` field is only set for outgoing connections.
+- Peer objects now have `remoteaddr` field (set for both incoming and outgoing connections); `addr` field removed.
+- `cluster.call`/`send` and the `serve` `call` callback now operate on a raw `data` string — the `marshal`/`unmarshal` config options and the integer `cmd` argument are removed; serialization and dispatch are left to the business layer. Cluster sessions are now 64-bit; request and response wire headers use `[session(8)][traceid(8)]` and `[session(8)]` respectively. This is a breaking wire-protocol change requiring all peers to upgrade together.
 
 ### Fixed
+- Cluster now drops responses that arrive after their request timed out instead of attempting to wake a missing coroutine.
 - Host header no longer duplicated when both the URL and user header table contain a host value.
 - Chunk size parsing handles missing hex before `tonumber` in h1.
 - h1 client now correctly skips 1xx informational responses (100, 103, etc.) and waits for the final response.

--- a/docs/src/en/reference/net/cluster.md
+++ b/docs/src/en/reference/net/cluster.md
@@ -28,44 +28,29 @@ The cluster module adopts a client-server model where each node can act as both 
 
 Cluster internally uses the `silly.net.cluster.c` module to implement a binary protocol:
 
-- **Request Packet**: `[2-byte length][business data][traceid(8 bytes)][cmd(4 bytes)][session(4 bytes)]`
-- **Response Packet**: `[2-byte length][business data][session(4 bytes)]`
+- **Request Packet**: `[4-byte length][session(8 bytes)][traceid(8 bytes)][business data]`
+- **Response Packet**: `[4-byte length][session(8 bytes)][business data]`
 - **Session Mechanism**: Uses session to automatically match requests and responses
 - **Timeout Control**: Supports setting timeout for each request
 - **Memory Management**: Buffers are automatically managed, no manual freeing required
 
-### Serialization Mechanism
+### Raw String Transport
 
-The cluster module is not bound to a specific serialization format and supports any encoding/decoding method through callback functions:
-
-- **marshal**: Encode Lua data into binary
-- **unmarshal**: Decode binary into Lua data
-- Common choices: zproto, protobuf, msgpack, json, etc.
+The cluster module is a raw string transport — it does not perform any serialization or deserialization. The `call` callback receives raw string data and returns raw string responses. Users are responsible for encoding/decoding using any format they prefer (zproto, protobuf, msgpack, json, etc.) inside their callbacks.
 
 ## API Reference
 
 ### cluster.serve(conf)
 
-Configure the global behavior of the cluster module, setting encoding/decoding, timeout, and callback functions.
+Configure the global behavior of the cluster module, setting timeout and callback functions.
 
 **Parameters:**
 
 - `conf` (table) - Configuration table containing the following fields:
-  - `marshal` (function) - **Required**, encoding function: `function(type, cmd, body) -> cmd_number, data`
-    - `type`: "request" or "response"
-    - `cmd`: Command identifier (string or number)
-    - `body`: Lua data to encode
-    - Returns: command number, data string (returning nil means no data is sent, e.g., no response)
-  - `unmarshal` (function) - **Required**, decoding function: `function(type, cmd, data) -> body, err?`
-    - `type`: "request" or "response"
-    - `cmd`: Command identifier
-    - `data`: Data string
-    - Returns: Decoded Lua data, optional error message
-  - `call` (function) - **Required**, RPC request handler: `function(peer, cmd, body) -> response`
+  - `call` (function) - **Required**, RPC request handler: `function(peer, data) -> response`
     - `peer`: Peer object of the connection
-    - `cmd`: Command identifier
-    - `body`: Decoded request data
-    - Returns: Response data (nil means no response needed)
+    - `data`: Raw string request data; dispatch (which procedure to run) is encoded by the caller inside this string — cluster is transport-only
+    - Returns: Raw string response data (nil means no response needed)
   - `close` (function) - Optional, connection close callback: `function(peer, errno)`
     - **Only triggered when the remote peer closes the connection**, actively calling `cluster.close()` does not trigger this callback
     - `peer`: Peer object of the connection
@@ -73,6 +58,8 @@ Configure the global behavior of the cluster module, setting encoding/decoding, 
   - `accept` (function) - Optional, new connection callback: `function(peer)`
     - `peer`: Peer object of the new connection (contains `remoteaddr` field for client address)
   - `timeout` (number) - Optional, RPC timeout in milliseconds, default 5000
+  - `hardlimit` (number) - Optional, max body size before error (default 128MB)
+  - `softlimit` (number) - Optional, max body size before warning (default 65535)
 
 **Returns:**
 
@@ -81,98 +68,29 @@ Configure the global behavior of the cluster module, setting encoding/decoding, 
 **Notes:**
 
 - `cluster.serve()` must be called before using other cluster functions
-- Peer objects contain `fd`, `remoteaddr` fields, and connect-returned peers also have `addr` field for auto-reconnect
-- Peers with addr support automatic reconnection
+- Peer objects contain `fd` and `remoteaddr` fields
 
 **Example:**
 
 ```lua validate
 local silly = require "silly"
 local cluster = require "silly.net.cluster"
-local zproto = require "zproto"
 
--- Define protocol
-local proto = zproto:parse [[
-ping 0x01 {
-    .msg:string 1
-}
-pong 0x02 {
-    .msg:string 1
-}
-]]
-
--- Encoding function
-local function marshal(typ, cmd, body)
-    if typ == "response" then
-        -- If body is nil, it means no response needs to be sent
-        if not body then
-            return nil
-        end
-        -- Convert ping to pong for responses
-        if cmd == "ping" or cmd == 0x01 then
-            cmd = "pong"
-        end
-    end
-
-    if type(cmd) == "string" then
-        cmd = proto:tag(cmd)
-    end
-
-    local dat, sz = proto:encode(cmd, body, true)
-    local buf = proto:pack(dat, sz, false)
-    return cmd, buf
-end
-
--- Decoding function
-local function unmarshal(typ, cmd, buf)
-    if typ == "response" then
-        if cmd == "ping" or cmd == 0x01 then
-            cmd = "pong"
-        end
-    end
-
-    local dat, sz = proto:unpack(buf, #buf, true)
-    local body = proto:decode(cmd, dat, sz)
-    return body
-end
-
--- Configure server
 cluster.serve {
     timeout = 3000,
-    marshal = marshal,
-    unmarshal = unmarshal,
     accept = function(peer)
         print("New connection from:", peer.remoteaddr)
     end,
-    call = function(peer, cmd, body)
-        print("Received request:", body.msg)
-        return {msg = "Hello from server"}
+    call = function(peer, data)
+        return "pong:" .. data
     end,
     close = function(peer, errno)
         print("Connection closed, errno:", errno)
     end,
 }
 
--- Start listening
 local listener = cluster.listen("127.0.0.1:8888")
 print("Server listening: 127.0.0.1:8888")
-
-local silly = require "silly"
-local cluster = require "silly.net.cluster"
-local zproto = require "zproto"
-local task = require "silly.task"
-
--- ... (omitted intermediate code)
-
--- Create client and test
-task.fork(function()
-    local peer = cluster.connect("127.0.0.1:8888")
-
-    local resp = cluster.call(peer, "ping", {msg = "Hello"})
-    print("Received response:", resp and resp.msg or "nil")
-
-    cluster.close(peer)
-end)
 ```
 
 ---
@@ -197,58 +115,11 @@ Listen for TCP connections on the specified address.
 - After successful listen, new connections will trigger the `accept` callback
 - The listener object can be used with `cluster.close()` to close the listener
 
-**Example:**
-
-```lua validate
-local silly = require "silly"
-local cluster = require "silly.net.cluster"
-local zproto = require "zproto"
-
-local proto = zproto:parse [[
-echo 0x01 {
-    .text:string 1
-}
-]]
-
-cluster.serve {
-    marshal = function(typ, cmd, body)
-        if typ == "response" and not body then
-            return nil
-        end
-        if type(cmd) == "string" then
-            cmd = proto:tag(cmd)
-        end
-        local dat, sz = proto:encode(cmd, body, true)
-        local buf = proto:pack(dat, sz, false)
-        return cmd, buf
-    end,
-    unmarshal = function(typ, cmd, buf)
-        local dat, sz = proto:unpack(buf, #buf, true)
-        return proto:decode(cmd, dat, sz)
-    end,
-    accept = function(peer)
-        print(string.format("Accept connection from %s", peer.remoteaddr))
-    end,
-    call = function(peer, cmd, body)
-        return body
-    end,
-    close = function(peer, errno)
-        print(string.format("Connection closed, error: %s", errno))
-    end,
-}
-
--- Listen on multiple ports
-local listener1 = cluster.listen("0.0.0.0:8888")
-local listener2 = cluster.listen("0.0.0.0:8889", 256)
-
-print("Listening on ports: 8888, 8889")
-```
-
 ---
 
 ### cluster.connect(addr)
 
-Create a peer handle for the given address. The handle records the address for use by later `cluster.call()` / `cluster.send()`; the actual TCP connect (and DNS lookup) is deferred to the first RPC call. This is a **synchronous** operation.
+Connect to a remote cluster node. Performs DNS lookup and TCP connect immediately (eager connect). This is an **asynchronous operation** and must be called in a coroutine.
 
 **Parameters:**
 
@@ -256,184 +127,71 @@ Create a peer handle for the given address. The handle records the address for u
 
 **Returns:**
 
-- `peer` (handle) - Peer handle (opaque table)
+- `peer` (table|nil) - On success, returns peer handle with `fd` and `remoteaddr` fields
+- `err` (string|nil) - On failure, returns error message
 
 **Notes:**
 
-- Can be called from any context — it does not yield.
-- Always returns a peer handle immediately; the first `cluster.call()` / `cluster.send()` performs the DNS lookup and TCP connect, and surfaces any error from there.
-- When a `cluster.connect`-created peer's connection drops (remote close), the next `call` / `send` transparently reconnects to the recorded address. Peers handed to the `accept` callback do **not** have that address and therefore cannot reconnect.
+- **Must be called from a coroutine** (e.g., inside `task.fork()`)
+- Returns immediately with a connected peer, or `nil, err` on failure
+- If the connection drops later, `call`/`send` returns `"Peer closed"` — there is no automatic reconnection
+- To reconnect after a drop, call `cluster.connect()` again to get a new peer
 
 **Example:**
 
 ```lua validate
 local silly = require "silly"
-local cluster = require "silly.net.cluster"
-local zproto = require "zproto"
-
-local proto = zproto:parse [[
-request 0x01 {
-    .data:string 1
-}
-]]
-
-cluster.serve {
-    marshal = function(typ, cmd, body)
-        if typ == "response" and not body then
-            return nil
-        end
-        if type(cmd) == "string" then
-            cmd = proto:tag(cmd)
-        end
-        local dat, sz = proto:encode(cmd, body, true)
-        local buf = proto:pack(dat, sz, false)
-        return cmd, buf
-    end,
-    unmarshal = function(typ, cmd, buf)
-        local dat, sz = proto:unpack(buf, #buf, true)
-        return proto:decode(cmd, dat, sz)
-    end,
-    call = function() end,
-    close = function() end,
-}
-
-local silly = require "silly"
-local cluster = require "silly.net.cluster"
-local zproto = require "zproto"
 local task = require "silly.task"
-
--- ... (omitted intermediate code)
+local cluster = require "silly.net.cluster"
 
 task.fork(function()
-    -- Generate peer handles
-    local peer1 = cluster.connect("127.0.0.1:8888")
-    local peer2 = cluster.connect("example.com:80")
-
-    -- Use peer handle directly without checking connection status
-    -- cluster.call() automatically handles reconnection
-    local resp, err = cluster.call(peer1, "request", {data = "test"})
-    if not resp then
-        print("Call failed:", err)
+    local peer, err = cluster.connect("127.0.0.1:8888")
+    if not peer then
+        print("Connect failed:", err)
+        return
     end
-
-    cluster.close(peer1)
-end)
-```
-
----
-
-### cluster.call(peer, cmd, obj)
-
-Send an RPC request and wait for a response. This is an **asynchronous operation** and must be called in a coroutine.
-
-**Parameters:**
-
-- `peer` (table) - Peer object (obtained from `cluster.connect()` or accept callback)
-- `cmd` (string|number) - Command identifier
-- `obj` (any) - Request data (will be encoded via marshal)
-
-**Returns:**
-
-- `response` (any|nil) - On success, returns response data (decoded via unmarshal)
-- `err` (silly.errno|string|nil) - On failure: a [`silly.errno`](../errno.md) value (e.g. `errno.TIMEDOUT`, `errno.CONNREFUSED`) for transport-level issues, or a string from the marshal/unmarshal path.
-
-**Notes:**
-
-- Must be called in a coroutine created by `task.fork()`
-- On timeout, returns `nil, errno.TIMEDOUT`
-- If the peer has no addr (came from the `accept` callback), a `call` after disconnect returns `nil, "peer closed"`
-- Automatically handles session matching and timeout control
-
-**Example:**
-
-```lua validate
-local silly = require "silly"
-local time = require "silly.time"
-local cluster = require "silly.net.cluster"
-local zproto = require "zproto"
-
-local proto = zproto:parse [[
-add 0x01 {
-    .a:integer 1
-    .b:integer 2
-}
-sum 0x02 {
-    .result:integer 1
-}
-]]
-
--- Server side
-cluster.serve {
-    timeout = 2000,
-    marshal = function(typ, cmd, body)
-        if typ == "response" then
-            if not body then
-                return nil
-            end
-            if cmd == "add" then
-                cmd = "sum"
-            end
-        end
-        if type(cmd) == "string" then
-            cmd = proto:tag(cmd)
-        end
-        local dat, sz = proto:encode(cmd, body, true)
-        local buf = proto:pack(dat, sz, false)
-        return cmd, buf
-    end,
-    unmarshal = function(typ, cmd, buf)
-        if typ == "response" and cmd == "add" then
-            cmd = "sum"
-        end
-        local dat, sz = proto:unpack(buf, #buf, true)
-        return proto:decode(cmd, dat, sz)
-    end,
-    accept = function() end,
-    call = function(peer, cmd, body)
-        -- Calculate addition
-        return {result = body.a + body.b}
-    end,
-    close = function() end,
-}
-
-cluster.listen("127.0.0.1:9999")
-
-local silly = require "silly"
-local time = require "silly.time"
-local cluster = require "silly.net.cluster"
-local zproto = require "zproto"
-local task = require "silly.task"
-
--- ... (omitted intermediate code)
-
--- Client test
-task.fork(function()
-    time.sleep(100)
-    local peer = cluster.connect("127.0.0.1:9999")
-
-    -- Send request and wait for response
-    local resp, err = cluster.call(peer, "add", {a = 10, b = 20})
+    -- peer is ready to use immediately
+    local resp, err = cluster.call(peer, "hello")
     if resp then
-        print("Calculation result:", resp.result)  -- Output: 30
-    else
-        print("Call failed:", err)
+        print("Response:", resp)
     end
-
     cluster.close(peer)
 end)
 ```
 
 ---
 
-### cluster.send(peer, cmd, obj)
+### cluster.call(peer, data)
+
+Send an RPC request and wait for a response. This is an **asynchronous operation** and must be called in a coroutine.
+
+**Parameters:**
+
+- `peer` (table) - Peer object (obtained from `cluster.connect()` or accept callback)
+- `data` (string) - Raw string request data; encode any dispatch key your server needs inside this string
+
+**Returns:**
+
+- `response` (string|nil) - On success, returns raw string response data
+- `err` (string|nil) - On failure: error string (e.g. timeout, connection error)
+
+**Notes:**
+
+- Must be called in a coroutine created by `task.fork()`
+- On timeout, returns `nil, errno.TIMEDOUT`
+- If the peer's connection has dropped, returns `nil, "Peer closed"`
+- Automatically handles session matching and timeout control
+
+---
+
+### cluster.send(peer, data)
 
 Send a one-way message without waiting for a response. This is an **asynchronous operation** and must be called in a coroutine.
 
 **Parameters:**
 
 - `peer` (table) - Peer object
-- `cmd` (string|number) - Command identifier
-- `obj` (any) - Message data
+- `data` (string) - Raw string message data
 
 **Returns:**
 
@@ -445,78 +203,6 @@ Send a one-way message without waiting for a response. This is an **asynchronous
 - Must be called in a coroutine created by `task.fork()`
 - Unlike `call`, send does not wait for a response
 - Suitable for notifications, log pushing, and other scenarios that don't require responses
-- If connection is disconnected but peer has addr, will automatically reconnect
-
-**Example:**
-
-```lua validate
-local silly = require "silly"
-local time = require "silly.time"
-local cluster = require "silly.net.cluster"
-local zproto = require "zproto"
-
-local proto = zproto:parse [[
-notify 0x10 {
-    .message:string 1
-}
-]]
-
--- Server receives notifications
-cluster.serve {
-    marshal = function(typ, cmd, body)
-        if typ == "response" and not body then
-            return nil
-        end
-        if type(cmd) == "string" then
-            cmd = proto:tag(cmd)
-        end
-        local dat, sz = proto:encode(cmd, body, true)
-        local buf = proto:pack(dat, sz, false)
-        return cmd, buf
-    end,
-    unmarshal = function(typ, cmd, buf)
-        local dat, sz = proto:unpack(buf, #buf, true)
-        return proto:decode(cmd, dat, sz)
-    end,
-    accept = function() end,
-    call = function(peer, cmd, body)
-        print("Received notification:", body.message)
-        -- One-way message does not return response
-        return nil
-    end,
-    close = function() end,
-}
-
-cluster.listen("127.0.0.1:7777")
-
-local silly = require "silly"
-local time = require "silly.time"
-local cluster = require "silly.net.cluster"
-local zproto = require "zproto"
-local task = require "silly.task"
-
--- ... (omitted intermediate code)
-
--- Client sends notifications
-task.fork(function()
-    time.sleep(100)
-    local peer = cluster.connect("127.0.0.1:7777")
-
-    -- Send multiple notifications
-    for i = 1, 5 do
-        local ok, err = cluster.send(peer, "notify", {
-            message = "Notification #" .. i
-        })
-        if not ok then
-            print("Send failed:", err)
-            break
-        end
-        time.sleep(100)
-    end
-
-    cluster.close(peer)
-end)
-```
 
 ---
 
@@ -535,485 +221,87 @@ Close a connection or listener.
 **Notes:**
 
 - Can close client connections, accepted connections, or listeners
-- Actively closed connections **do not** trigger the `close` callback and **do not** automatically reconnect
+- Actively closed connections **do not** trigger the `close` callback
 - Peer handles should not be used after closing
-
-**Example:**
-
-```lua validate
-local silly = require "silly"
-local cluster = require "silly.net.cluster"
-local zproto = require "zproto"
-
-local proto = zproto:parse [[
-test 0x01 {
-    .x:integer 1
-}
-]]
-
-cluster.serve {
-    marshal = function(typ, cmd, body)
-        if typ == "response" and not body then
-            return nil
-        end
-        if type(cmd) == "string" then
-            cmd = proto:tag(cmd)
-        end
-        local dat, sz = proto:encode(cmd, body, true)
-        local buf = proto:pack(dat, sz, false)
-        return cmd, buf
-    end,
-    unmarshal = function(typ, cmd, buf)
-        local dat, sz = proto:unpack(buf, #buf, true)
-        return proto:decode(cmd, dat, sz)
-    end,
-    accept = function() end,
-    call = function() end,
-    close = function(peer, errno)
-        print("Connection closed, errno:", errno)
-    end,
-}
-
-local silly = require "silly"
-local cluster = require "silly.net.cluster"
-local zproto = require "zproto"
-local task = require "silly.task"
-
--- ... (omitted intermediate code)
-
-local listener = cluster.listen("127.0.0.1:6666")
-
-task.fork(function()
-    local peer = cluster.connect("127.0.0.1:6666")
-
-    -- Actively close connection
-    cluster.close(peer)
-    print("Peer closed")
-
-    -- Close listener
-    cluster.close(listener)
-end)
-```
 
 ---
 
-## Complete Examples
+## Complete Example
 
 ### Simple RPC Service
 
 ```lua validate
 local silly = require "silly"
+local task = require "silly.task"
 local cluster = require "silly.net.cluster"
-local zproto = require "zproto"
-
-local proto = zproto:parse [[
-ping 0x01 {
-    .msg:string 1
-}
-pong 0x02 {
-    .msg:string 1
-}
-]]
-
-local function marshal(typ, cmd, body)
-    if typ == "response" then
-        if not body then
-            return nil
-        end
-        if cmd == "ping" or cmd == 0x01 then
-            cmd = "pong"
-        end
-    end
-    if type(cmd) == "string" then
-        cmd = proto:tag(cmd)
-    end
-    local dat, sz = proto:encode(cmd, body, true)
-    return cmd, proto:pack(dat, sz, false)
-end
-
-local function unmarshal(typ, cmd, buf)
-    if typ == "response" and (cmd == "ping" or cmd == 0x01) then
-        cmd = "pong"
-    end
-    local dat, sz = proto:unpack(buf, #buf, true)
-    return proto:decode(cmd, dat, sz)
-end
 
 cluster.serve {
-    marshal = marshal,
-    unmarshal = unmarshal,
+    timeout = 3000,
     accept = function(peer)
         print("New connection from:", peer.remoteaddr)
     end,
-    call = function(peer, cmd, body)
-        print("Received:", body.msg)
-        return {msg = "pong from server"}
+    call = function(peer, data)
+        return "pong:" .. data
     end,
     close = function(peer, errno)
         print("Connection closed, errno:", errno)
     end,
 }
 
-local silly = require "silly"
-local cluster = require "silly.net.cluster"
-local zproto = require "zproto"
-local task = require "silly.task"
-
--- ... (omitted intermediate code)
-
 cluster.listen("127.0.0.1:8888")
 
 task.fork(function()
-    local peer = cluster.connect("127.0.0.1:8888")
-    local resp = cluster.call(peer, "ping", {msg = "ping"})
-    print("Response:", resp.msg)
+    local peer, err = cluster.connect("127.0.0.1:8888")
+    if not peer then
+        print("Connect failed:", err)
+        return
+    end
+    local resp = cluster.call(peer, "ping")
+    print("Response:", resp)
     cluster.close(peer)
 end)
 ```
 
----
+### With Custom Serialization
 
-### Multi-Node Cluster Communication
+Users can use any serialization library inside their `call` callback:
 
 ```lua validate
 local silly = require "silly"
-local time = require "silly.time"
-local cluster = require "silly.net.cluster"
-local zproto = require "zproto"
-
--- Define cluster protocol
-local proto = zproto:parse [[
-register 0x01 {
-    .node_id:string 1
-    .addr:string 2
-}
-heartbeat 0x02 {
-    .timestamp:integer 1
-}
-forward 0x03 {
-    .target:string 1
-    .data:string 2
-}
-]]
-
-local function marshal(typ, cmd, body)
-    if typ == "response" and not body then
-        return nil
-    end
-    if type(cmd) == "string" then
-        cmd = proto:tag(cmd)
-    end
-    local dat, sz = proto:encode(cmd, body, true)
-    return cmd, proto:pack(dat, sz, false)
-end
-
-local function unmarshal(typ, cmd, buf)
-    local dat, sz = proto:unpack(buf, #buf, true)
-    return proto:decode(cmd, dat, sz)
-end
-
--- Node information
-local nodes = {}
-
--- Create node server
-local function create_node(node_id, port)
-    cluster.serve {
-        timeout = 5000,
-        marshal = marshal,
-        unmarshal = unmarshal,
-        accept = function(peer)
-            print(string.format("[%s] Accept connection: %s", node_id, peer.remoteaddr))
-            nodes[peer.remoteaddr] = peer
-        end,
-        call = function(peer, cmd, body)
-            if cmd == 0x01 then  -- register
-                print(string.format("[%s] Node registered: %s @ %s",
-                    node_id, body.node_id, body.addr))
-                return {status = "ok"}
-            elseif cmd == 0x02 then  -- heartbeat
-                return {timestamp = os.time()}
-            elseif cmd == 0x03 then  -- forward
-                print(string.format("[%s] Forward message to %s: %s",
-                    node_id, body.target, body.data))
-                return {result = "forwarded"}
-            end
-        end,
-        close = function(peer, errno)
-            print(string.format("[%s] Node disconnected", node_id))
-        end,
-    }
-
-    local listener = cluster.listen("127.0.0.1:" .. port)
-    print(string.format("[%s] Listening on port: %d", node_id, port))
-    return listener
-end
-
--- Create three nodes
-local node1 = create_node("node1", 10001)
-local node2 = create_node("node2", 10002)
-local node3 = create_node("node3", 10003)
-
-local silly = require "silly"
-local time = require "silly.time"
-local cluster = require "silly.net.cluster"
-local zproto = require "zproto"
 local task = require "silly.task"
-
--- ... (omitted intermediate code)
-
--- Node interconnection
-task.fork(function()
-    time.sleep(100)
-
-    -- node2 connects to node1
-    local peer2 = cluster.connect("127.0.0.1:10001")
-    local resp = cluster.call(peer2, "register", {
-        node_id = "node2",
-        addr = "127.0.0.1:10002"
-    })
-    print("Registration response:", resp and resp.status or "nil")
-
-    -- Send heartbeat
-    time.sleep(500)
-    local hb = cluster.call(peer2, "heartbeat", {
-        timestamp = os.time()
-    })
-    print("Heartbeat response:", hb and hb.timestamp or "nil")
-
-    -- node3 connects to node1
-    local peer3 = cluster.connect("127.0.0.1:10001")
-    cluster.call(peer3, "register", {
-        node_id = "node3",
-        addr = "127.0.0.1:10003"
-    })
-
-    -- Forward message via node1
-    local fwd = cluster.call(peer3, "forward", {
-        target = "node2",
-        data = "Hello from node3"
-    })
-    print("Forward result:", fwd and fwd.result or "nil")
-end)
-```
-
----
-
-### Broadcast Message to All Nodes
-
-```lua validate
-local silly = require "silly"
-local time = require "silly.time"
 local cluster = require "silly.net.cluster"
-local zproto = require "zproto"
+local json = require "silly.encoding.json"
 
-local proto = zproto:parse [[
-broadcast 0x20 {
-    .message:string 1
-}
-ack 0x21 {
-    .node_id:string 1
-}
-]]
-
--- Configure broadcast server
 cluster.serve {
-    timeout = 1000,
-    marshal = function(typ, cmd, body)
-        if typ == "response" then
-            if not body then
-                return nil
-            end
-            if cmd == "broadcast" then
-                cmd = "ack"
-            end
+    timeout = 5000,
+    call = function(peer, data)
+        local req = json.decode(data)
+        if req.action == "get_user" then
+            local user = {id = req.id, name = "Alice"}
+            return json.encode(user)
+        elseif req.action == "set_user" then
+            -- process the request
+            return json.encode({ok = true})
         end
-        if type(cmd) == "string" then
-            cmd = proto:tag(cmd)
-        end
-        local dat, sz = proto:encode(cmd, body, true)
-        local buf = proto:pack(dat, sz, false)
-        return cmd, buf
-    end,
-    unmarshal = function(typ, cmd, buf)
-        if typ == "response" and cmd == "broadcast" then
-            cmd = "ack"
-        end
-        local dat, sz = proto:unpack(buf, #buf, true)
-        return proto:decode(cmd, dat, sz)
     end,
     accept = function() end,
-    call = function(peer, cmd, body)
-        print("Received broadcast:", body.message)
-        return {node_id = "node_" .. os.time()}  -- Use other identifier
-    end,
     close = function() end,
 }
 
--- Start 3 receiver nodes
-local listeners = {}
-local ports = {8001, 8002, 8003}
-for _, port in ipairs(ports) do
-    local listener = cluster.listen("127.0.0.1:" .. port)
-    table.insert(listeners, listener)
-end
+cluster.listen("127.0.0.1:9000")
 
--- Broadcast client
-local silly = require "silly"
-local time = require "silly.time"
-local cluster = require "silly.net.cluster"
-local zproto = require "zproto"
-local task = require "silly.task"
-
--- ... (omitted intermediate code)
-
--- Broadcast client
 task.fork(function()
-    time.sleep(200)
-
-    -- Connect to all nodes
-    local peers = {}
-    for _, port in ipairs(ports) do
-        local peer = cluster.connect("127.0.0.1:" .. port)
-        table.insert(peers, peer)
+    local peer, err = cluster.connect("127.0.0.1:9000")
+    if not peer then
+        print("Connect failed:", err)
+        return
     end
-
-    -- Concurrent broadcast to all nodes
-    local message = "Important notice: System will be under maintenance in 10 minutes"
-    local acks = {}
-
-    for _, peer in ipairs(peers) do
-        task.fork(function()
-            local resp = cluster.call(peer, "broadcast", {
-                message = message
-            })
-            if resp then
-                table.insert(acks, resp.node_id)
-                print("Received ack:", resp.node_id)
-            end
-        end)
+    local resp = cluster.call(peer, json.encode({action = "get_user", id = 42}))
+    if resp then
+        local user = json.decode(resp)
+        print("User:", user.name)
     end
-
-    -- Wait for all responses
-    time.sleep(500)
-    print("Broadcast complete, ack count:", #acks)
-
-    -- Clean up connections
-    for _, peer in ipairs(peers) do
-        cluster.close(peer)
-    end
-end)
-```
-
----
-
-### Load Balanced Calls
-
-```lua validate
-local silly = require "silly"
-local time = require "silly.time"
-local cluster = require "silly.net.cluster"
-local zproto = require "zproto"
-
-local proto = zproto:parse [[
-work 0x30 {
-    .task_id:integer 1
-    .data:string 2
-}
-result 0x31 {
-    .task_id:integer 1
-    .output:string 2
-}
-]]
-
--- Configure cluster service
-cluster.serve {
-    timeout = 3000,
-    marshal = function(typ, cmd, body)
-        if typ == "response" then
-            if not body then
-                return nil
-            end
-            if cmd == "work" then
-                cmd = "result"
-            end
-        end
-        if type(cmd) == "string" then
-            cmd = proto:tag(cmd)
-        end
-        local dat, sz = proto:encode(cmd, body, true)
-        local buf = proto:pack(dat, sz, false)
-        return cmd, buf
-    end,
-    unmarshal = function(typ, cmd, buf)
-        if typ == "response" and cmd == "work" then
-            cmd = "result"
-        end
-        local dat, sz = proto:unpack(buf, #buf, true)
-        return proto:decode(cmd, dat, sz)
-    end,
-    accept = function() end,
-    call = function(peer, cmd, body)
-        -- Simulate work processing (use task_id to distinguish tasks)
-        local worker_id = (body.task_id % 3) + 1
-        print(string.format("[Worker %d] Processing task #%d: %s",
-            worker_id, body.task_id, body.data))
-        time.sleep(100 + math.random(200))
-        return {
-            task_id = body.task_id,
-            output = string.format("Worker %d completed", worker_id)
-        }
-    end,
-    close = function() end,
-}
-
--- Start 3 worker nodes
-local listeners = {}
-local ports = {9001, 9002, 9003}
-for _, port in ipairs(ports) do
-    local listener = cluster.listen("127.0.0.1:" .. port)
-    table.insert(listeners, listener)
-end
-
--- Load balancer client
-local silly = require "silly"
-local time = require "silly.time"
-local cluster = require "silly.net.cluster"
-local zproto = require "zproto"
-local task = require "silly.task"
-
--- ... (omitted intermediate code)
-
--- Load balancer client
-task.fork(function()
-    time.sleep(200)
-
-    -- Connect to all worker nodes
-    local worker_peers = {}
-    for _, port in ipairs(ports) do
-        local peer = cluster.connect("127.0.0.1:" .. port)
-        table.insert(worker_peers, peer)
-    end
-
-    -- Round-robin task distribution
-    local current = 1
-    for task_id = 1, 10 do
-        local peer = worker_peers[current]
-
-        task.fork(function()
-            local resp = cluster.call(peer, "work", {
-                task_id = task_id,
-                data = "Task data " .. task_id
-            })
-            if resp then
-                print(string.format("Task #%d result: %s",
-                    resp.task_id, resp.output))
-            end
-        end)
-
-        -- Round-robin to next worker node
-        current = (current % #worker_peers) + 1
-        time.sleep(50)
-    end
+    cluster.close(peer)
 end)
 ```
 
@@ -1023,28 +311,32 @@ end)
 
 ### Coroutine Requirements
 
-All asynchronous operations (`connect`, `call`, `send`) must be called in coroutines created by `task.fork()`:
+`cluster.connect`, `cluster.call`, and `cluster.send` must be called in coroutines created by `task.fork()`:
 
 ```lua
--- ❌ Wrong: Direct call will error
-local peer = cluster.connect("127.0.0.1:8888")
+-- ❌ Wrong: Direct call will error (cluster.connect yields)
+local peer, err = cluster.connect("127.0.0.1:8888")
 
 -- ✅ Correct: Call in coroutine
 task.fork(function()
-    local peer = cluster.connect("127.0.0.1:8888")
+    local peer, err = cluster.connect("127.0.0.1:8888")
+    if not peer then
+        print("Connect failed:", err)
+        return
+    end
+    -- use peer...
 end)
 ```
 
-### Peer Handles and Auto-Reconnection
+### Peer Handles
 
-- **Peer handles from connect**: Support auto-reconnection
-  - Peer handles save address information (`addr` and `remoteaddr`)
-  - When **remote peer closes connection**, next `call()` or `send()` will automatically reconnect
-  - **Connections closed by actively calling `cluster.close()` do not auto-reconnect**
+- **Peer handles from connect**: Have `fd` and `remoteaddr` fields
+  - Connection is established immediately by `cluster.connect()`
+  - When the connection drops, `call`/`send` returns `"Peer closed"`
+  - **No automatic reconnection** — call `cluster.connect()` again to get a new peer
 
-- **Peer handles from accept callback**: Do not support auto-reconnection
-  - Inbound connection peer handles have `remoteaddr` but no `addr`
-  - After disconnection, cannot auto-reconnect, will return `nil, "peer closed"`
+- **Peer handles from accept callback**: Have `fd` and `remoteaddr` fields
+  - Behave identically to connect-created peers once connected
 
 - **Listener handles**: Used for listening on ports
   - Can be closed via `cluster.close()`
@@ -1055,17 +347,29 @@ end)
 - On timeout, returns `nil, errno.TIMEDOUT`
 - Timed-out requests are cleaned up, delayed responses are ignored
 
-### Serialization Notes
+### Error Handling
 
-- `marshal` returns `(cmd_number, data)`:
-  - First return value must be numeric command ID
-  - Second return value is encoded string data
-  - No need to return size, length is automatically obtained from string
+`cluster.call` / `cluster.send` errors are **opaque strings** from the caller's perspective — do not `err == errno.X` against them. Log or propagate the value; put retry / fallback decisions elsewhere.
 
-- `unmarshal` receives string parameter:
-  - Parameter `buf` is a Lua string, can directly use `#buf` to get length
-  - No manual memory management needed, buffer is automatically converted to string
-  - Returns decoded Lua table and optional error message
+```lua
+local logger = require "silly.logger"
+
+task.fork(function()
+    local peer, err = cluster.connect(addr)
+    if not peer then
+        logger.error("cluster connect failed:", err)
+        return
+    end
+
+    local resp, err = cluster.call(peer, data)
+    if not resp then
+        logger.error("cluster call failed:", err)
+        return
+    end
+
+    -- Process response...
+end)
+```
 
 ### Distributed Tracing
 
@@ -1073,13 +377,13 @@ Cluster automatically propagates trace IDs:
 
 ```lua
 -- Client initiates request, automatically carries current trace ID using trace.propagate()
-local resp = cluster.call(peer, "ping", data)
+local resp = cluster.call(peer, data)
 
 -- Server processes, trace ID is automatically set by cluster
-call = function(peer, cmd, body)
+call = function(peer, data)
     -- logger automatically uses current trace ID for logging
     -- Enables distributed tracing across services
-    logger.info("Processing request:", cmd)
+    logger.info("Processing request")
 end
 ```
 
@@ -1090,30 +394,6 @@ end
 3. **Reasonable Timeouts**: Set appropriate timeout based on business needs
 4. **Serialization Choice**: Prioritize binary protocols (zproto, protobuf)
 5. **Connection Pool**: For high-concurrency scenarios, maintain a connection pool
-
-### Error Handling
-
-`cluster.call` / `cluster.send` errors are **opaque strings** from the caller's perspective — do not `err == errno.X` against them, even if you see `errno.TIMEDOUT` today. Log or propagate the value; put retry / fallback decisions elsewhere.
-
-```lua
-local logger = require "silly.logger"
-
-task.fork(function()
-    -- cluster.connect always returns a peer handle
-    local peer = cluster.connect(addr)
-
-    -- cluster.call's error return is declared as `string?`, so treat
-    -- `err` as an opaque diagnostic string — log it, but do not branch
-    -- on its content.
-    local resp, err = cluster.call(peer, cmd, data)
-    if not resp then
-        logger.error("cluster call failed:", err)
-        return
-    end
-
-    -- Process response...
-end)
-```
 
 ---
 

--- a/docs/src/reference/net/cluster.md
+++ b/docs/src/reference/net/cluster.md
@@ -28,44 +28,29 @@ cluster 模块采用客户端-服务器模型，每个节点既可以作为服�
 
 cluster 内部使用 `silly.net.cluster.c` 模块实现二进制协议：
 
-- **请求包**：`[2字节长度][业务数据][traceid(8字节)][cmd(4字节)][session(4字节)]`
-- **响应包**：`[2字节长度][业务数据][session(4字节)]`
+- **请求包**：`[4字节长度][session(8字节)][traceid(8字节)][业务数据]`
+- **响应包**：`[4字节长度][session(8字节)][业务数据]`
 - **会话机制**：使用 session 自动匹配请求和响应
 - **超时控制**：支持为每个请求设置超时时间
 - **内存管理**：buffer 自动管理，无需手动释放
 
-### 序列化机制
+### 裸字符串传输
 
-cluster 模块不绑定特定的序列化格式，通过配置回调函数支持任意编解码方式：
-
-- **marshal**：将 Lua 数据编码为二进制
-- **unmarshal**：将二进制解码为 Lua 数据
-- 常见选择：zproto、protobuf、msgpack、json 等
+cluster 模块是裸字符串传输层——不做任何序列化或反序列化。`call` 回调接收原始字符串数据并返回原始字符串响应。用户在自己的回调中使用任意格式（zproto、protobuf、msgpack、json 等）进行编解码。
 
 ## API 参考
 
 ### cluster.serve(conf)
 
-配置 cluster 模块的全局行为，设置编解码、超时和回调函数。
+配置 cluster 模块的全局行为，设置超时和回调函数。
 
 **参数：**
 
 - `conf` (table) - 配置表，包含以下字段：
-  - `marshal` (function) - **必需**，编码函数：`function(type, cmd, body) -> cmd_number, data`
-    - `type`："request" 或 "response"
-    - `cmd`：命令标识（字符串或数字）
-    - `body`：要编码的 Lua 数据
-    - 返回：命令数字、数据字符串（若返回 nil 则表示不发送数据，例如不发送响应）
-  - `unmarshal` (function) - **必需**，解码函数：`function(type, cmd, data) -> body, err?`
-    - `type`："request" 或 "response"
-    - `cmd`：命令标识
-    - `data`：数据字符串
-    - 返回：解码后的 Lua 数据，可选错误信息
-  - `call` (function) - **必需**，RPC 请求处理函数：`function(peer, cmd, body) -> response`
+  - `call` (function) - **必需**，RPC 请求处理函数：`function(peer, data) -> response`
     - `peer`：连接的 peer 对象
-    - `cmd`：命令标识
-    - `body`：解码后的请求数据
-    - 返回：响应数据（nil 表示不需要响应）
+    - `data`：原始字符串请求数据；分派（执行哪个过程）由调用方在该字符串内自行编码——cluster 只是传输层
+    - 返回：原始字符串响应数据（nil 表示不需要响应）
   - `close` (function) - 可选，连接关闭回调：`function(peer, errno)`
     - **仅在对端关闭连接时触发**，主动调用 `cluster.close()` 不会触发此回调
     - `peer`：连接的 peer 对象
@@ -73,6 +58,8 @@ cluster 模块不绑定特定的序列化格式，通过配置回调函数支持
   - `accept` (function) - 可选，新连接回调：`function(peer)`
     - `peer`：新连接的 peer 对象（含 `remoteaddr` 字段表示客户端地址）
   - `timeout` (number) - 可选，RPC 超时时间（毫秒），默认 5000
+  - `hardlimit` (number) - 可选，最大 body 大小限制，超过则报错（默认 128MB）
+  - `softlimit` (number) - 可选，最大 body 大小警告阈值（默认 65535）
 
 **返回值：**
 
@@ -81,98 +68,29 @@ cluster 模块不绑定特定的序列化格式，通过配置回调函数支持
 **注意：**
 
 - `cluster.serve()` 必须在使用其他 cluster 函数之前调用
-- peer 对象包含 `fd`、`remoteaddr` 字段，connect 返回的 peer 还有 `addr` 字段用于自动重连
-- 有 addr 的 peer 支持自动重连
+- peer 对象包含 `fd` 和 `remoteaddr` 字段
 
 **示例：**
 
 ```lua validate
 local silly = require "silly"
 local cluster = require "silly.net.cluster"
-local zproto = require "zproto"
 
--- 定义协议
-local proto = zproto:parse [[
-ping 0x01 {
-    .msg:string 1
-}
-pong 0x02 {
-    .msg:string 1
-}
-]]
-
--- 编码函数
-local function marshal(typ, cmd, body)
-    if typ == "response" then
-        -- 如果 body 为 nil，表示不需要发送响应
-        if not body then
-            return nil
-        end
-        -- 响应时将 ping 转换为 pong
-        if cmd == "ping" or cmd == 0x01 then
-            cmd = "pong"
-        end
-    end
-
-    if type(cmd) == "string" then
-        cmd = proto:tag(cmd)
-    end
-
-    local dat, sz = proto:encode(cmd, body, true)
-    local buf = proto:pack(dat, sz, false)
-    return cmd, buf
-end
-
--- 解码函数
-local function unmarshal(typ, cmd, buf)
-    if typ == "response" then
-        if cmd == "ping" or cmd == 0x01 then
-            cmd = "pong"
-        end
-    end
-
-    local dat, sz = proto:unpack(buf, #buf, true)
-    local body = proto:decode(cmd, dat, sz)
-    return body
-end
-
--- 配置服务器
 cluster.serve {
     timeout = 3000,
-    marshal = marshal,
-    unmarshal = unmarshal,
     accept = function(peer)
-        print("新连接来自:", peer.remoteaddr)
+        print("New connection from:", peer.remoteaddr)
     end,
-    call = function(peer, cmd, body)
-        print("收到请求:", body.msg)
-        return {msg = "Hello from server"}
+    call = function(peer, data)
+        return "pong:" .. data
     end,
     close = function(peer, errno)
-        print("连接关闭, errno:", errno)
+        print("Connection closed, errno:", errno)
     end,
 }
 
--- 启动监听
 local listener = cluster.listen("127.0.0.1:8888")
-print("服务器监听: 127.0.0.1:8888")
-
-local silly = require "silly"
-local cluster = require "silly.net.cluster"
-local zproto = require "zproto"
-local task = require "silly.task"
-
--- ... (省略中间代码)
-
--- 创建客户端并测试
-task.fork(function()
-    local peer = cluster.connect("127.0.0.1:8888")
-
-    local resp = cluster.call(peer, "ping", {msg = "Hello"})
-    print("收到响应:", resp and resp.msg or "nil")
-
-    cluster.close(peer)
-end)
+print("Server listening: 127.0.0.1:8888")
 ```
 
 ---
@@ -197,58 +115,11 @@ end)
 - 监听成功后，新连接会触发 `accept` 回调
 - listener 对象可用于 `cluster.close()` 关闭监听
 
-**示例：**
-
-```lua validate
-local silly = require "silly"
-local cluster = require "silly.net.cluster"
-local zproto = require "zproto"
-
-local proto = zproto:parse [[
-echo 0x01 {
-    .text:string 1
-}
-]]
-
-cluster.serve {
-    marshal = function(typ, cmd, body)
-        if typ == "response" and not body then
-            return nil
-        end
-        if type(cmd) == "string" then
-            cmd = proto:tag(cmd)
-        end
-        local dat, sz = proto:encode(cmd, body, true)
-        local buf = proto:pack(dat, sz, false)
-        return cmd, buf
-    end,
-    unmarshal = function(typ, cmd, buf)
-        local dat, sz = proto:unpack(buf, #buf, true)
-        return proto:decode(cmd, dat, sz)
-    end,
-    accept = function(peer)
-        print(string.format("接受连接来自 %s", peer.remoteaddr))
-    end,
-    call = function(peer, cmd, body)
-        return body
-    end,
-    close = function(peer, errno)
-        print(string.format("连接关闭，错误: %s", errno))
-    end,
-}
-
--- 监听多个端口
-local listener1 = cluster.listen("0.0.0.0:8888")
-local listener2 = cluster.listen("0.0.0.0:8889", 256)
-
-print("监听端口: 8888, 8889")
-```
-
 ---
 
 ### cluster.connect(addr)
 
-为指定地址创建一个 peer handle。handle 只记录地址供后续 `cluster.call()` / `cluster.send()` 使用；真正的 DNS 解析和 TCP connect 延迟到第一次 RPC 调用时才发生。这是一个**同步操作**。
+连接到远程集群节点。立即执行 DNS 解析和 TCP 连接（eager connect）。这是一个**异步操作**，必须在协程中调用。
 
 **参数：**
 
@@ -256,185 +127,71 @@ print("监听端口: 8888, 8889")
 
 **返回值：**
 
-- `peer` (handle) - 对端 handle（不透明 table）
+- `peer` (table|nil) - 成功返回 peer 对象，包含 `fd` 和 `remoteaddr` 字段
+- `err` (string|nil) - 失败返回错误信息
 
 **注意：**
 
-- 可以在任何上下文调用——不会 yield。
-- 无论目标是否可达都会立即返回 peer handle；实际的连接建立/解析在第一次 `call` / `send` 时进行，错误也在那里返回。
-- `cluster.connect` 创建的 peer 在连接断开（远端关闭）后，下次 `call` / `send` 会使用记录的地址透明重连。而 `accept` 回调里拿到的 peer 没有 addr 字段，**无法**重连。
+- **必须在协程中调用**（例如在 `task.fork()` 内）
+- 成功时立即返回已连接的 peer，失败时返回 `nil, err`
+- 连接断开后，`call`/`send` 返回 `"Peer closed"`——**不会自动重连**
+- 要在断开后重新连接，再次调用 `cluster.connect()` 获取新的 peer
 
 **示例：**
 
 ```lua validate
 local silly = require "silly"
-local cluster = require "silly.net.cluster"
-local zproto = require "zproto"
-
-local proto = zproto:parse [[
-request 0x01 {
-    .data:string 1
-}
-]]
-
-cluster.serve {
-    marshal = function(typ, cmd, body)
-        if typ == "response" and not body then
-            return nil
-        end
-        if type(cmd) == "string" then
-            cmd = proto:tag(cmd)
-        end
-        local dat, sz = proto:encode(cmd, body, true)
-        local buf = proto:pack(dat, sz, false)
-        return cmd, buf
-    end,
-    unmarshal = function(typ, cmd, buf)
-        local dat, sz = proto:unpack(buf, #buf, true)
-        return proto:decode(cmd, dat, sz)
-    end,
-    call = function() end,
-    close = function() end,
-}
-
-local silly = require "silly"
-local cluster = require "silly.net.cluster"
-local zproto = require "zproto"
 local task = require "silly.task"
-
--- ... (省略中间代码)
+local cluster = require "silly.net.cluster"
 
 task.fork(function()
-    -- 生成对端 handle
-    local peer1 = cluster.connect("127.0.0.1:8888")
-    local peer2 = cluster.connect("example.com:80")
-
-    -- 直接使用 peer handle，无需检查连接状态
-    -- cluster.call() 会自动处理重连
-    local resp, err = cluster.call(peer1, "request", {data = "test"})
-    if not resp then
-        print("调用失败:", err)
+    local peer, err = cluster.connect("127.0.0.1:8888")
+    if not peer then
+        print("Connect failed:", err)
+        return
     end
-
-    cluster.close(peer1)
-end)
-```
-
----
-
-### cluster.call(peer, cmd, obj)
-
-发送 RPC 请求并等待响应。这是一个**异步操作**，必须在协程中调用。
-
-**参数：**
-
-- `peer` (table) - peer 对象（由 `cluster.connect()` 或 accept 回调获得）
-- `cmd` (string|number) - 命令标识
-- `obj` (any) - 请求数据（会通过 marshal 编码）
-
-**返回值：**
-
-- `response` (any|nil) - 成功返回响应数据（通过 unmarshal 解码）
-- `err` (silly.errno|string|nil) - 失败时返回错误：传输层问题为 [`silly.errno`](../errno.md) 值（例如 `errno.TIMEDOUT`、`errno.CONNREFUSED`）；marshal/unmarshal 路径上的错误为字符串。
-
-**注意：**
-
-- 必须在 `task.fork()` 创建的协程中调用
-- 如果超时，返回 `nil, errno.TIMEDOUT`
-- 如果连接已关闭但 peer 有 addr，会自动重连
-- 如果 peer 无 addr（accept 产生的），连接断开后返回 `nil, "peer closed"`
-- 自动处理 session 匹配和超时控制
-
-**示例：**
-
-```lua validate
-local silly = require "silly"
-local time = require "silly.time"
-local cluster = require "silly.net.cluster"
-local zproto = require "zproto"
-
-local proto = zproto:parse [[
-add 0x01 {
-    .a:integer 1
-    .b:integer 2
-}
-sum 0x02 {
-    .result:integer 1
-}
-]]
-
--- 服务器端
-cluster.serve {
-    timeout = 2000,
-    marshal = function(typ, cmd, body)
-        if typ == "response" then
-            if not body then
-                return nil
-            end
-            if cmd == "add" then
-                cmd = "sum"
-            end
-        end
-        if type(cmd) == "string" then
-            cmd = proto:tag(cmd)
-        end
-        local dat, sz = proto:encode(cmd, body, true)
-        local buf = proto:pack(dat, sz, false)
-        return cmd, buf
-    end,
-    unmarshal = function(typ, cmd, buf)
-        if typ == "response" and cmd == "add" then
-            cmd = "sum"
-        end
-        local dat, sz = proto:unpack(buf, #buf, true)
-        return proto:decode(cmd, dat, sz)
-    end,
-    accept = function() end,
-    call = function(peer, cmd, body)
-        -- 计算加法
-        return {result = body.a + body.b}
-    end,
-    close = function() end,
-}
-
-cluster.listen("127.0.0.1:9999")
-
-local silly = require "silly"
-local time = require "silly.time"
-local cluster = require "silly.net.cluster"
-local zproto = require "zproto"
-local task = require "silly.task"
-
--- ... (省略中间代码)
-
--- 客户端测试
-task.fork(function()
-    time.sleep(100)
-    local peer = cluster.connect("127.0.0.1:9999")
-
-    -- 发送请求并等待响应
-    local resp, err = cluster.call(peer, "add", {a = 10, b = 20})
+    -- peer is ready to use immediately
+    local resp, err = cluster.call(peer, "hello")
     if resp then
-        print("计算结果:", resp.result)  -- 输出: 30
-    else
-        print("调用失败:", err)
+        print("Response:", resp)
     end
-
     cluster.close(peer)
 end)
 ```
 
 ---
 
-### cluster.send(peer, cmd, obj)
+### cluster.call(peer, data)
+
+发送 RPC 请求并等待响应。这是一个**异步操作**，必须在协程中调用。
+
+**参数：**
+
+- `peer` (table) - peer 对象（由 `cluster.connect()` 或 accept 回调获得）
+- `data` (string) - 原始字符串请求数据；服务端所需的任何分派 key 都由你自行编码在该字符串内
+
+**返回值：**
+
+- `response` (string|nil) - 成功返回原始字符串响应数据
+- `err` (string|nil) - 失败时返回错误字符串（例如超时、连接错误）
+
+**注意：**
+
+- 必须在 `task.fork()` 创建的协程中调用
+- 超时后返回 `nil, errno.TIMEDOUT`
+- 如果 peer 的连接已断开，返回 `nil, "Peer closed"`
+- 自动处理 session 匹配和超时控制
+
+---
+
+### cluster.send(peer, data)
 
 发送单向消息，不等待响应。这是一个**异步操作**，必须在协程中调用。
 
 **参数：**
 
 - `peer` (table) - peer 对象
-- `cmd` (string|number) - 命令标识
-- `obj` (any) - 消息数据
+- `data` (string) - 原始字符串消息数据
 
 **返回值：**
 
@@ -446,78 +203,6 @@ end)
 - 必须在 `task.fork()` 创建的协程中调用
 - 与 `call` 不同，send 不等待响应
 - 适用于通知、日志推送等无需响应的场景
-- 如果连接断开但 peer 有 addr，会自动重连
-
-**示例：**
-
-```lua validate
-local silly = require "silly"
-local time = require "silly.time"
-local cluster = require "silly.net.cluster"
-local zproto = require "zproto"
-
-local proto = zproto:parse [[
-notify 0x10 {
-    .message:string 1
-}
-]]
-
--- 服务器接收通知
-cluster.serve {
-    marshal = function(typ, cmd, body)
-        if typ == "response" and not body then
-            return nil
-        end
-        if type(cmd) == "string" then
-            cmd = proto:tag(cmd)
-        end
-        local dat, sz = proto:encode(cmd, body, true)
-        local buf = proto:pack(dat, sz, false)
-        return cmd, buf
-    end,
-    unmarshal = function(typ, cmd, buf)
-        local dat, sz = proto:unpack(buf, #buf, true)
-        return proto:decode(cmd, dat, sz)
-    end,
-    accept = function() end,
-    call = function(peer, cmd, body)
-        print("收到通知:", body.message)
-        -- 单向消息不返回响应
-        return nil
-    end,
-    close = function() end,
-}
-
-cluster.listen("127.0.0.1:7777")
-
-local silly = require "silly"
-local time = require "silly.time"
-local cluster = require "silly.net.cluster"
-local zproto = require "zproto"
-local task = require "silly.task"
-
--- ... (省略中间代码)
-
--- 客户端发送通知
-task.fork(function()
-    time.sleep(100)
-    local peer = cluster.connect("127.0.0.1:7777")
-
-    -- 发送多条通知
-    for i = 1, 5 do
-        local ok, err = cluster.send(peer, "notify", {
-            message = "通知 #" .. i
-        })
-        if not ok then
-            print("发送失败:", err)
-            break
-        end
-        time.sleep(100)
-    end
-
-    cluster.close(peer)
-end)
-```
 
 ---
 
@@ -536,65 +221,8 @@ end)
 **注意：**
 
 - 可以关闭客户端连接、accept 的连接或监听器
-- 主动关闭的连接**不会**触发 `close` 回调，也**不会**自动重连
-- peer handle 关闭后不应再使用
-
-**示例：**
-
-```lua validate
-local silly = require "silly"
-local cluster = require "silly.net.cluster"
-local zproto = require "zproto"
-
-local proto = zproto:parse [[
-test 0x01 {
-    .x:integer 1
-}
-]]
-
-cluster.serve {
-    marshal = function(typ, cmd, body)
-        if typ == "response" and not body then
-            return nil
-        end
-        if type(cmd) == "string" then
-            cmd = proto:tag(cmd)
-        end
-        local dat, sz = proto:encode(cmd, body, true)
-        local buf = proto:pack(dat, sz, false)
-        return cmd, buf
-    end,
-    unmarshal = function(typ, cmd, buf)
-        local dat, sz = proto:unpack(buf, #buf, true)
-        return proto:decode(cmd, dat, sz)
-    end,
-    accept = function() end,
-    call = function() end,
-    close = function(peer, errno)
-        print("连接已关闭, errno:", errno)
-    end,
-}
-
-local silly = require "silly"
-local cluster = require "silly.net.cluster"
-local zproto = require "zproto"
-local task = require "silly.task"
-
--- ... (省略中间代码)
-
-local listener = cluster.listen("127.0.0.1:6666")
-
-task.fork(function()
-    local peer = cluster.connect("127.0.0.1:6666")
-
-    -- 主动关闭连接
-    cluster.close(peer)
-    print("peer 已关闭")
-
-    -- 关闭监听器
-    cluster.close(listener)
-end)
-```
+- 主动关闭的连接**不会**触发 `close` 回调
+- peer 关闭后不应再使用
 
 ---
 
@@ -604,417 +232,76 @@ end)
 
 ```lua validate
 local silly = require "silly"
+local task = require "silly.task"
 local cluster = require "silly.net.cluster"
-local zproto = require "zproto"
-
-local proto = zproto:parse [[
-ping 0x01 {
-    .msg:string 1
-}
-pong 0x02 {
-    .msg:string 1
-}
-]]
-
-local function marshal(typ, cmd, body)
-    if typ == "response" then
-        if not body then
-            return nil
-        end
-        if cmd == "ping" or cmd == 0x01 then
-            cmd = "pong"
-        end
-    end
-    if type(cmd) == "string" then
-        cmd = proto:tag(cmd)
-    end
-    local dat, sz = proto:encode(cmd, body, true)
-    return cmd, proto:pack(dat, sz, false)
-end
-
-local function unmarshal(typ, cmd, buf)
-    if typ == "response" and (cmd == "ping" or cmd == 0x01) then
-        cmd = "pong"
-    end
-    local dat, sz = proto:unpack(buf, #buf, true)
-    return proto:decode(cmd, dat, sz)
-end
 
 cluster.serve {
-    marshal = marshal,
-    unmarshal = unmarshal,
+    timeout = 3000,
     accept = function(peer)
-        print("新连接来自:", peer.remoteaddr)
+        print("New connection from:", peer.remoteaddr)
     end,
-    call = function(peer, cmd, body)
-        print("收到:", body.msg)
-        return {msg = "pong from server"}
+    call = function(peer, data)
+        return "pong:" .. data
     end,
     close = function(peer, errno)
-        print("连接关闭, errno:", errno)
+        print("Connection closed, errno:", errno)
     end,
 }
-
-local silly = require "silly"
-local cluster = require "silly.net.cluster"
-local zproto = require "zproto"
-local task = require "silly.task"
-
--- ... (省略中间代码)
 
 cluster.listen("127.0.0.1:8888")
 
 task.fork(function()
-    local peer = cluster.connect("127.0.0.1:8888")
-    local resp = cluster.call(peer, "ping", {msg = "ping"})
-    print("响应:", resp.msg)
+    local peer, err = cluster.connect("127.0.0.1:8888")
+    if not peer then
+        print("Connect failed:", err)
+        return
+    end
+    local resp = cluster.call(peer, "ping")
+    print("Response:", resp)
     cluster.close(peer)
 end)
 ```
 
----
+### 自定义序列化
 
-### 多节点集群通信
+用户可以在 `call` 回调中使用任意序列化库：
 
 ```lua validate
 local silly = require "silly"
-local time = require "silly.time"
-local cluster = require "silly.net.cluster"
-local zproto = require "zproto"
-
--- 定义集群协议
-local proto = zproto:parse [[
-register 0x01 {
-    .node_id:string 1
-    .addr:string 2
-}
-heartbeat 0x02 {
-    .timestamp:integer 1
-}
-forward 0x03 {
-    .target:string 1
-    .data:string 2
-}
-]]
-
-local function marshal(typ, cmd, body)
-    if typ == "response" and not body then
-        return nil
-    end
-    if type(cmd) == "string" then
-        cmd = proto:tag(cmd)
-    end
-    local dat, sz = proto:encode(cmd, body, true)
-    return cmd, proto:pack(dat, sz, false)
-end
-
-local function unmarshal(typ, cmd, buf)
-    local dat, sz = proto:unpack(buf, #buf, true)
-    return proto:decode(cmd, dat, sz)
-end
-
--- 节点信息
-local nodes = {}
-
--- 创建节点服务器
-local function create_node(node_id, port)
-    cluster.serve {
-        timeout = 5000,
-        marshal = marshal,
-        unmarshal = unmarshal,
-        accept = function(peer)
-            print(string.format("[%s] 接受连接: %s", node_id, peer.remoteaddr))
-            nodes[peer.remoteaddr] = peer
-        end,
-        call = function(peer, cmd, body)
-            if cmd == 0x01 then  -- register
-                print(string.format("[%s] 节点注册: %s @ %s",
-                    node_id, body.node_id, body.addr))
-                return {status = "ok"}
-            elseif cmd == 0x02 then  -- heartbeat
-                return {timestamp = os.time()}
-            elseif cmd == 0x03 then  -- forward
-                print(string.format("[%s] 转发消息到 %s: %s",
-                    node_id, body.target, body.data))
-                return {result = "forwarded"}
-            end
-        end,
-        close = function(peer, errno)
-            print(string.format("[%s] 节点断开", node_id))
-        end,
-    }
-
-    local listener = cluster.listen("127.0.0.1:" .. port)
-    print(string.format("[%s] 监听端口: %d", node_id, port))
-    return listener
-end
-
--- 创建三个节点
-local node1 = create_node("node1", 10001)
-local node2 = create_node("node2", 10002)
-local node3 = create_node("node3", 10003)
-
-local silly = require "silly"
-local time = require "silly.time"
-local cluster = require "silly.net.cluster"
-local zproto = require "zproto"
 local task = require "silly.task"
-
--- ... (省略中间代码)
-
--- 节点互联
-task.fork(function()
-    time.sleep(100)
-
-    -- node2 连接到 node1
-    local peer2 = cluster.connect("127.0.0.1:10001")
-    local resp = cluster.call(peer2, "register", {
-        node_id = "node2",
-        addr = "127.0.0.1:10002"
-    })
-    print("注册响应:", resp and resp.status or "nil")
-
-    -- 发送心跳
-    time.sleep(500)
-    local hb = cluster.call(peer2, "heartbeat", {
-        timestamp = os.time()
-    })
-    print("心跳响应:", hb and hb.timestamp or "nil")
-
-    -- node3 连接到 node1
-    local peer3 = cluster.connect("127.0.0.1:10001")
-    cluster.call(peer3, "register", {
-        node_id = "node3",
-        addr = "127.0.0.1:10003"
-    })
-
-    -- 通过 node1 转发消息
-    local fwd = cluster.call(peer3, "forward", {
-        target = "node2",
-        data = "Hello from node3"
-    })
-    print("转发结果:", fwd and fwd.result or "nil")
-end)
-```
-
----
-
-### 广播消息到所有节点
-
-```lua validate
-local silly = require "silly"
-local time = require "silly.time"
 local cluster = require "silly.net.cluster"
-local zproto = require "zproto"
+local json = require "silly.encoding.json"
 
-local proto = zproto:parse [[
-broadcast 0x20 {
-    .message:string 1
-}
-ack 0x21 {
-    .node_id:string 1
-}
-]]
-
--- 配置广播服务器
 cluster.serve {
-    timeout = 1000,
-    marshal = function(typ, cmd, body)
-        if typ == "response" then
-            if not body then
-                return nil
-            end
-            if cmd == "broadcast" then
-                cmd = "ack"
-            end
+    timeout = 5000,
+    call = function(peer, data)
+        local req = json.decode(data)
+        if req.action == "get_user" then
+            local user = {id = req.id, name = "Alice"}
+            return json.encode(user)
+        elseif req.action == "set_user" then
+            -- process the request
+            return json.encode({ok = true})
         end
-        if type(cmd) == "string" then
-            cmd = proto:tag(cmd)
-        end
-        local dat, sz = proto:encode(cmd, body, true)
-        local buf = proto:pack(dat, sz, false)
-        return cmd, buf
-    end,
-    unmarshal = function(typ, cmd, buf)
-        if typ == "response" and cmd == "broadcast" then
-            cmd = "ack"
-        end
-        local dat, sz = proto:unpack(buf, #buf, true)
-        return proto:decode(cmd, dat, sz)
     end,
     accept = function() end,
-    call = function(peer, cmd, body)
-        print("接收广播:", body.message)
-        return {node_id = "node_" .. os.time()}  -- 使用其他标识符
-    end,
     close = function() end,
 }
 
--- 启动 3 个接收节点
-local listeners = {}
-local ports = {8001, 8002, 8003}
-for _, port in ipairs(ports) do
-    local listener = cluster.listen("127.0.0.1:" .. port)
-    table.insert(listeners, listener)
-end
+cluster.listen("127.0.0.1:9000")
 
--- 广播客户端
-local silly = require "silly"
-local time = require "silly.time"
-local cluster = require "silly.net.cluster"
-local zproto = require "zproto"
-local task = require "silly.task"
-
--- ... (省略中间代码)
-
--- 广播客户端
 task.fork(function()
-    time.sleep(200)
-
-    -- 连接所有节点
-    local peers = {}
-    for _, port in ipairs(ports) do
-        local peer = cluster.connect("127.0.0.1:" .. port)
-        table.insert(peers, peer)
+    local peer, err = cluster.connect("127.0.0.1:9000")
+    if not peer then
+        print("Connect failed:", err)
+        return
     end
-
-    -- 并发广播到所有节点
-    local message = "重要通知：系统将于 10 分钟后维护"
-    local acks = {}
-
-    for _, peer in ipairs(peers) do
-        task.fork(function()
-            local resp = cluster.call(peer, "broadcast", {
-                message = message
-            })
-            if resp then
-                table.insert(acks, resp.node_id)
-                print("收到确认:", resp.node_id)
-            end
-        end)
+    local resp = cluster.call(peer, json.encode({action = "get_user", id = 42}))
+    if resp then
+        local user = json.decode(resp)
+        print("User:", user.name)
     end
-
-    -- 等待所有响应
-    time.sleep(500)
-    print("广播完成，确认数:", #acks)
-
-    -- 清理连接
-    for _, peer in ipairs(peers) do
-        cluster.close(peer)
-    end
-end)
-```
-
----
-
-### 负载均衡调用
-
-```lua validate
-local silly = require "silly"
-local time = require "silly.time"
-local cluster = require "silly.net.cluster"
-local zproto = require "zproto"
-
-local proto = zproto:parse [[
-work 0x30 {
-    .task_id:integer 1
-    .data:string 2
-}
-result 0x31 {
-    .task_id:integer 1
-    .output:string 2
-}
-]]
-
--- 配置 cluster 服务
-cluster.serve {
-    timeout = 3000,
-    marshal = function(typ, cmd, body)
-        if typ == "response" then
-            if not body then
-                return nil
-            end
-            if cmd == "work" then
-                cmd = "result"
-            end
-        end
-        if type(cmd) == "string" then
-            cmd = proto:tag(cmd)
-        end
-        local dat, sz = proto:encode(cmd, body, true)
-        local buf = proto:pack(dat, sz, false)
-        return cmd, buf
-    end,
-    unmarshal = function(typ, cmd, buf)
-        if typ == "response" and cmd == "work" then
-            cmd = "result"
-        end
-        local dat, sz = proto:unpack(buf, #buf, true)
-        return proto:decode(cmd, dat, sz)
-    end,
-    accept = function() end,
-    call = function(peer, cmd, body)
-        -- 模拟工作处理（使用 task_id 来区分任务）
-        local worker_id = (body.task_id % 3) + 1
-        print(string.format("[Worker %d] 处理任务 #%d: %s",
-            worker_id, body.task_id, body.data))
-        time.sleep(100 + math.random(200))
-        return {
-            task_id = body.task_id,
-            output = string.format("Worker %d 完成", worker_id)
-        }
-    end,
-    close = function() end,
-}
-
--- 启动 3 个工作节点
-local listeners = {}
-local ports = {9001, 9002, 9003}
-for _, port in ipairs(ports) do
-    local listener = cluster.listen("127.0.0.1:" .. port)
-    table.insert(listeners, listener)
-end
-
--- 负载均衡器客户端
-local silly = require "silly"
-local time = require "silly.time"
-local cluster = require "silly.net.cluster"
-local zproto = require "zproto"
-local task = require "silly.task"
-
--- ... (省略中间代码)
-
--- 负载均衡器客户端
-task.fork(function()
-    time.sleep(200)
-
-    -- 连接所有工作节点
-    local worker_peers = {}
-    for _, port in ipairs(ports) do
-        local peer = cluster.connect("127.0.0.1:" .. port)
-        table.insert(worker_peers, peer)
-    end
-
-    -- 轮询分发任务
-    local current = 1
-    for task_id = 1, 10 do
-        local peer = worker_peers[current]
-
-        task.fork(function()
-            local resp = cluster.call(peer, "work", {
-                task_id = task_id,
-                data = "任务数据 " .. task_id
-            })
-            if resp then
-                print(string.format("任务 #%d 结果: %s",
-                    resp.task_id, resp.output))
-            end
-        end)
-
-        -- 轮询到下一个工作节点
-        current = (current % #worker_peers) + 1
-        time.sleep(50)
-    end
+    cluster.close(peer)
 end)
 ```
 
@@ -1024,31 +311,35 @@ end)
 
 ### 协程要求
 
-所有异步操作（`connect`、`call`、`send`）必须在 `task.fork()` 创建的协程中调用：
+`cluster.connect`、`cluster.call` 和 `cluster.send` 必须在 `task.fork()` 创建的协程中调用：
 
 ```lua
--- ❌ 错误：直接调用会报错
-local peer = cluster.connect("127.0.0.1:8888")
+-- ❌ Wrong: Direct call will error (cluster.connect yields)
+local peer, err = cluster.connect("127.0.0.1:8888")
 
--- ✅ 正确：在协程中调用
+-- ✅ Correct: Call in coroutine
 task.fork(function()
-    local peer = cluster.connect("127.0.0.1:8888")
+    local peer, err = cluster.connect("127.0.0.1:8888")
+    if not peer then
+        print("Connect failed:", err)
+        return
+    end
+    -- use peer...
 end)
 ```
 
-### Peer Handle 和自动重连
+### Peer 对象
 
-- **connect 返回的 peer handle**：支持自动重连
-  - peer handle 保存了地址信息（`addr` 和 `remoteaddr`）
-  - 当**对端关闭连接**时，下次 `call()` 或 `send()` 会自动重连
-  - **主动调用 `cluster.close()` 关闭的连接不会自动重连**
+- **connect 返回的 peer**：包含 `fd` 和 `remoteaddr` 字段
+  - 连接由 `cluster.connect()` 立即建立
+  - 连接断开后，`call`/`send` 返回 `"Peer closed"`
+  - **不会自动重连**——再次调用 `cluster.connect()` 获取新的 peer
 
-- **accept 回调的 peer handle**：不支持自动重连
-  - 入站连接的 peer handle 有 `remoteaddr` 但无 `addr`
-  - 连接断开后无法自动重连，会返回 `nil, "peer closed"`
+- **accept 回调的 peer**：包含 `fd` 和 `remoteaddr` 字段
+  - 行为与 connect 创建的 peer 一致
 
-- **listener handle**：用于监听端口
-  - 通过 `cluster.close()` 可以关闭监听器
+- **listener 对象**：用于监听端口
+  - 通过 `cluster.close()` 关闭监听器
 
 ### 超时控制
 
@@ -1056,31 +347,43 @@ end)
 - 超时后返回 `nil, errno.TIMEDOUT`
 - 超时的请求会被清理，延迟到达的响应会被忽略
 
-### 序列化注意事项
+### 错误处理
 
-- `marshal` 返回 `(cmd_number, data)`：
-  - 第一个返回值必须是数字类型的命令 ID
-  - 第二个返回值是编码后的字符串数据
-  - 无需返回 size，自动从字符串获取长度
+从调用方看，`cluster.call` / `cluster.send` 的错误是**不透明字符串**——不要 `err == errno.X` 做分支判断。把值记日志、原样透传；重试/降级决策放在别处。
 
-- `unmarshal` 接收字符串参数：
-  - 参数 `buf` 是 Lua 字符串，可直接使用 `#buf` 获取长度
-  - 无需手动管理内存，buffer 已自动转换为字符串
-  - 返回解码后的 Lua 表和可选的错误信息
+```lua
+local logger = require "silly.logger"
+
+task.fork(function()
+    local peer, err = cluster.connect(addr)
+    if not peer then
+        logger.error("cluster connect failed:", err)
+        return
+    end
+
+    local resp, err = cluster.call(peer, data)
+    if not resp then
+        logger.error("cluster call failed:", err)
+        return
+    end
+
+    -- Process response...
+end)
+```
 
 ### 分布式追踪
 
 cluster 自动传播 trace ID：
 
 ```lua
--- 客户端发起请求时，自动使用 trace.propagate() 携带当前 trace ID
-local resp = cluster.call(peer, "ping", data)
+-- Client initiates request, automatically carries current trace ID using trace.propagate()
+local resp = cluster.call(peer, data)
 
--- 服务器端处理时，trace ID 已由 cluster 自动设置
-call = function(peer, cmd, body)
-    -- logger 会自动使用当前 trace ID 记录日志
-    -- 实现跨服务的分布式追踪
-    logger.info("Processing request:", cmd)
+-- Server processes, trace ID is automatically set by cluster
+call = function(peer, data)
+    -- logger automatically uses current trace ID for logging
+    -- Enables distributed tracing across services
+    logger.info("Processing request")
 end
 ```
 
@@ -1091,30 +394,6 @@ end
 3. **合理超时**：根据业务设置合适的超时时间
 4. **序列化选择**：优先使用二进制协议（zproto、protobuf）
 5. **连接池**：对于高并发场景，可以维护连接池
-
-### 错误处理
-
-从调用方看，`cluster.call` / `cluster.send` 的错误是**不透明字符串**——即便今天看到的是 `errno.TIMEDOUT`，也不要 `err == errno.X`。把值记日志、原样透传给调用方；重试/降级决策放在别处。
-
-```lua
-local logger = require "silly.logger"
-
-task.fork(function()
-    -- cluster.connect 总是返回 peer handle
-    local peer = cluster.connect(addr)
-
-    -- cluster.call 的错误返回类型声明为 `string?`，因此把 err
-    -- 当作不透明的诊断字符串——打印到日志即可，不要对其内容
-    -- 做分支判断。
-    local resp, err = cluster.call(peer, cmd, data)
-    if not resp then
-        logger.error("cluster call failed:", err)
-        return
-    end
-
-    -- 处理响应...
-end)
-```
 
 ---
 

--- a/luaclib-src/lcluster.c
+++ b/luaclib-src/lcluster.c
@@ -8,29 +8,24 @@
 
 #include "silly.h"
 
-#define ACK_BIT (1UL << 31)
+#define ACK_BIT (UINT64_C(1) << 63)
 #define DEFAULT_QUEUE_SIZE 2048
 #define DEFAULT_HARDLIMIT (128u * 1024 * 1024)
 #define HASH_SIZE 2048
 #define HASH(a) (a % HASH_SIZE)
 
-typedef uint32_t cmd_t;
-typedef uint32_t session_t;
+typedef uint64_t session_t;
 
 #define HEADER_SIZE 4
-
-struct request_header {
-	session_t session;
-	cmd_t cmd;
-	silly_traceid_t traceid;
-};
-static_assert(sizeof(struct request_header) == 16,
-	"request_header layout mismatch");
+/* Wire request body header: [session(8)][traceid(8)]. */
+#define REQUEST_HEADER_SIZE 16
+static_assert(REQUEST_HEADER_SIZE == sizeof(session_t) + sizeof(silly_traceid_t),
+	"REQUEST_HEADER_SIZE must be session(8) + traceid(8)");
 
 struct response_header {
 	session_t session;
 };
-static_assert(sizeof(struct response_header) == 4,
+static_assert(sizeof(struct response_header) == 8,
 	"response_header layout mismatch");
 struct packet {
 	silly_socket_id_t fd;
@@ -207,7 +202,7 @@ static inline int validate_payload(struct incomplete *ic)
 	memcpy(&resp_hdr, ic->buff, sizeof(resp_hdr));
 	if ((resp_hdr.session & ACK_BIT) == ACK_BIT)
 		return 0;
-	if (unlikely(ic->header.psize < sizeof(struct request_header))) {
+	if (unlikely(ic->header.psize < REQUEST_HEADER_SIZE)) {
 		silly_log_error("[cluster] request size %u too small from fd %" PRIu64 "\n",
 			ic->header.psize, (uint64_t)ic->fd);
 		return ERR_PSIZE;
@@ -350,6 +345,7 @@ static int lpop(lua_State *L)
 	char *buf;
 	int size;
 	session_t session;
+	silly_traceid_t traceid;
 	struct response_header rsp_hdr;
 	struct packet *pk = pop_packet(L);
 	if (pk == NULL)
@@ -370,46 +366,41 @@ static int lpop(lua_State *L)
 				extstr_free, buf);
 		}
 		lua_pushinteger(L, (lua_Integer)(session & ~ACK_BIT));
-		lua_pushnil(L);        //cmd
-		lua_pushinteger(L, 0); //traceid
+		lua_pushnil(L);               //responses carry no traceid
 	} else {
-		struct request_header req_hdr;
-		memcpy(&req_hdr, buf, sizeof(req_hdr));
-		size = pk->size - sizeof(struct request_header);
+		memcpy(&traceid, buf + sizeof(session), sizeof(traceid));
+		size = pk->size - REQUEST_HEADER_SIZE;
 		lua_pushinteger(L, pk->fd);
 		if (size == 0) {
 			silly_free(buf);
 			lua_pushliteral(L, "");
 		} else {
 			lua_pushexternalstring(L,
-				buf + sizeof(struct request_header), size,
+				buf + REQUEST_HEADER_SIZE, size,
 				extstr_free, buf);
 		}
-		lua_pushinteger(L, req_hdr.session);
-		lua_pushinteger(L, req_hdr.cmd);
-		lua_pushinteger(L, (lua_Integer)req_hdr.traceid);
+		lua_pushinteger(L, session);
+		lua_pushinteger(L, (lua_Integer)traceid);
 	}
-	return 5;
+	return 4;
 }
 
-static inline int validate_pack_size(struct netpacket *np, cmd_t cmd,
-				     uint64_t size)
+static inline int validate_pack_size(struct netpacket *np, uint64_t size)
 {
 	if (unlikely(size > np->hardlimit)) {
-		silly_log_error("[cluster] %d size %" PRIu64 " exceeds hardlimit %u\n",
-				cmd, size, np->hardlimit);
+		silly_log_error("[cluster] size %" PRIu64 " exceeds hardlimit %u\n",
+				size, np->hardlimit);
 		return ERR_HARDLIMIT;
 	}
 	if (unlikely(size > np->softlimit)) {
-		silly_log_warn("[cluster] %d size %" PRIu64 " exceeds softlimit %u\n",
-			       cmd, size, np->softlimit);
+		silly_log_warn("[cluster] size %" PRIu64 " exceeds softlimit %u\n",
+			       size, np->softlimit);
 	}
 	return 0;
 }
 
 static int lrequest(lua_State *L)
 {
-	cmd_t cmd;
 	uint8_t *p;
 	const char *str;
 	size_t size;
@@ -417,18 +408,16 @@ static int lrequest(lua_State *L)
 	uint32_t total;
 	session_t session;
 	silly_traceid_t traceid;
-	struct request_header req_hdr;
 	struct netpacket *np = get_netpacket(L);
-	cmd = luaL_checkinteger(L, 2);
-	traceid = luaL_checkinteger(L, 3);
-	str = getbuffer(L, 4, &size);
+	traceid = luaL_checkinteger(L, 2);
+	str = getbuffer(L, 3, &size);
 	session = session_idx++;
 	if (session >= ACK_BIT) {
 		session_idx = 0;
 		session = 0;
 	}
-	body = sizeof(struct request_header) + size;
-	int err = validate_pack_size(np, cmd, body);
+	body = REQUEST_HEADER_SIZE + size;
+	int err = validate_pack_size(np, body);
 	if (unlikely(err < 0)) {
 		lua_pushboolean(L, 0);
 		lua_pushstring(L, error_str(err));
@@ -437,11 +426,9 @@ static int lrequest(lua_State *L)
 	total = HEADER_SIZE + body;
 	p = silly_malloc(total + 1);
 	memcpy(p, &body, HEADER_SIZE);
-	req_hdr.session = session;
-	req_hdr.cmd = cmd;
-	req_hdr.traceid = traceid;
-	memcpy(p + HEADER_SIZE, &req_hdr, sizeof(req_hdr));
-	memcpy(p + HEADER_SIZE + sizeof(struct request_header), str, size);
+	memcpy(p + HEADER_SIZE, &session, sizeof(session));
+	memcpy(p + HEADER_SIZE + sizeof(session), &traceid, sizeof(traceid));
+	memcpy(p + HEADER_SIZE + REQUEST_HEADER_SIZE, str, size);
 	p[total] = '\0';
 	lua_pushinteger(L, session);
 	lua_pushexternalstring(L, (char *)p, total, extstr_free, p);
@@ -458,10 +445,10 @@ static int lresponse(lua_State *L)
 	session_t session;
 	struct response_header rsp_hdr;
 	struct netpacket *np = get_netpacket(L);
-	session = luaL_checkinteger(L, 2) | ACK_BIT;
+	session = (session_t)luaL_checkinteger(L, 2) | ACK_BIT;
 	str = getbuffer(L, 3, &size);
 	body = sizeof(struct response_header) + size;
-	int err = validate_pack_size(np, 0, body);
+	int err = validate_pack_size(np, body);
 	if (unlikely(err < 0)) {
 		lua_pushboolean(L, 0);
 		lua_pushstring(L, error_str(err));

--- a/lualib/silly/net/cluster.lua
+++ b/lualib/silly/net/cluster.lua
@@ -1,7 +1,6 @@
 local silly = require "silly"
 local task = require "silly.task"
 local trace = require "silly.trace"
-local lock = require "silly.sync.mutex"
 local time = require "silly.time"
 local net = require "silly.net"
 local dns = require "silly.net.dns"
@@ -29,21 +28,14 @@ local ETIMEDOUT<const> = errno.TIMEDOUT
 ---@class silly.net.cluster.peer
 ---@field fd integer?
 ---@field remoteaddr string --Remote address; set for both incoming and outgoing connections.
----@field addr string? --Set for outgoing connections; used for auto-reconnect. Incoming connections lack this field.
 
 ---@class silly.net.cluster.listener
 ---@field fd integer
 
----@alias silly.net.cluster.marshal fun(typ:"request"|"response", cmd:integer|string, obj:table):integer, string
----@alias silly.net.cluster.unmarshal fun(typ:"request"|"response", cmd:integer|string, dat:string):table?, string? error
----@alias silly.net.cluster.call fun(peer:silly.net.cluster.peer, cmd:integer, obj:table):table?
+---@alias silly.net.cluster.call fun(peer:silly.net.cluster.peer, data:string):string?
 ---@alias silly.net.cluster.accept fun(peer:silly.net.cluster.peer)
 ---@alias silly.net.cluster.close fun(peer:silly.net.cluster.peer, errno:string)
 
----@type silly.net.cluster.marshal
-local marshal
----@type silly.net.cluster.unmarshal
-local unmarshal
 ---@type silly.net.cluster.accept
 local accept
 ---@type silly.net.cluster.close
@@ -55,61 +47,52 @@ local expire
 
 local wait_pool = {}
 local fd_to_peer = {}
-local connect_lock = lock.new()
 ---@type silly.net.cluster.context
 local ctx
 
 ---@class silly.net.cluster
 local M = {}
 local function process()
-	local fd, buf, session, cmd, traceid = c.pop(ctx)
+	local fd, buf, session, traceid = c.pop(ctx)
 	if not fd then
 		return
 	end
-	local otrace = trace_attach(traceid)
 	task.fork(process)
 	while true do
-		if cmd then	--rpc request
-			local req, resp, err
-			req, err = unmarshal("request", cmd, buf)
-			if not req then
-				logger.error("[cluster] decode fail",
-					session, cmd, err)
-				break
-			end
+		if traceid then	--rpc request
 			local peer = fd_to_peer[fd]
 			if not peer then
 				logger.error("[cluster] peer not found", fd)
-				break
+			else
+				local otrace = trace_attach(traceid)
+				local ok, res = pcall(call, peer, buf)
+				if not ok then
+					logger.error("[cluster] call error", res)
+				elseif res then
+					local resp, err = c.response(ctx, session, res)
+					if not resp then
+						logger.error("[cluster] response error:", err)
+					else
+						tcp_send(fd, resp)
+					end
+				end
+				trace_attach(otrace)
 			end
-			local ok, res = pcall(call, peer, cmd, req)
-			if not ok then
-				logger.error("[cluster] call error", res)
-				break
-			end
-			local id, res_data = marshal("response", cmd, res)
-			if not id then
-				break
-			end
-			resp, err = c.response(ctx, session, res_data)
-			if not resp then
-				logger.error("[cluster] response cmd:", cmd, "error:", err)
-				break
-			end
-			tcp_send(fd, resp)
 		else	-- rpc response
 			local co = wait_pool[session]
-			wait_pool[session] = nil
-			task.wakeup(co, buf)
+			if co then
+				wait_pool[session] = nil
+				task.wakeup(co, buf)
+			else
+				logger.debug("[cluster] late response session:", session)
+			end
 		end
 		--next
-		fd, buf, session, cmd, traceid = c.pop(ctx)
+		fd, buf, session, traceid = c.pop(ctx)
 		if not fd then
 			break
 		end
-		trace_attach(traceid)
 	end
-	trace_attach(otrace)
 end
 
 local function close_fd(fd, errno)
@@ -134,7 +117,6 @@ end
 ---@param peer silly.net.cluster.peer|silly.net.cluster.listener
 local function close_peer(peer)
 	local fd = peer.fd
-	peer.addr = nil
 	if fd then
 		peer.fd = nil
 		tcp_close(fd)
@@ -176,58 +158,32 @@ data = function(fd, ptr, size)
 end
 }
 
----@param peer silly.net.cluster.peer
-local function connect(peer)
-	local addr = peer.addr
-	if not addr then
-		return nil, "Peer closed"
-	end
-	local l<close> = connect_lock:lock(peer)
-	local fd = peer.fd
-	if fd then
-		return fd, nil
-	end
+---@param addr string
+---@return silly.net.cluster.peer?, string? error
+function M.connect(addr)
 	local name, port = parse_addr(addr)
 	if not name or not port then
-		return nil, "Invalid address:" .. addr
+		return nil, "Invalid address: " .. addr
 	end
+	local resolved = addr
 	if is_host(name) then
 		local ip, err = dns.lookup(name, dns.A)
 		if not ip then
 			return nil, format("dns lookup %s failed: %s", name, err)
 		end
-		addr = join_addr(ip, port)
+		resolved = join_addr(ip, port)
 	end
-	local err
-	fd, err = tcp_connect(addr, EVENT)
+	local fd, err = tcp_connect(resolved, EVENT)
 	logger.info("[cluster] connect", addr, "fd:", fd, "err:", err)
 	if not fd then
 		return nil, err
 	end
-	-- The peer may have been closed by another coroutine while we were
-	-- yielded in dns.lookup or tcp_connect. In that case peer.addr has
-	-- been cleared; discard the just-established fd so we don't hand
-	-- the caller a live connection on a peer it considers closed.
-	if not peer.addr then
-		tcp_close(fd)
-		return nil, "Peer closed"
-	end
-	peer.fd = fd
-	fd_to_peer[fd] = peer
-	return fd, nil
-end
-
----@param addr string
----@return silly.net.cluster.peer
-function M.connect(addr)
-	---@type silly.net.cluster.peer
 	local peer = {
-		fd = nil,
-		addr = addr,
+		fd = fd,
 		remoteaddr = addr,
 	}
-	logger.info("[cluster] connect peer", addr)
-	return peer
+	fd_to_peer[fd] = peer
+	return peer, nil
 end
 
 M.close = close_peer
@@ -258,39 +214,29 @@ local timer_func = function(session)
 	task.wakeup(co, nil)
 end
 
-local waitfor = function(session, cmd)
+local waitfor = function(session)
 	local co = task.running()
 	local timer_id = after(expire, timer_func, session)
 	wait_pool[session] = co
 	local body = task.wait()
 	if body then
 		cancel(timer_id)
-		local obj, err = unmarshal("response", cmd, body)
-		return obj, err
+		return body, nil
 	end
 	return nil, ETIMEDOUT
 end
 
 local function callx(is_send)
 	---@param peer silly.net.cluster.peer
-	---@param cmd string
-	---@param obj table
-	---@return table|boolean|nil result, string? error
-	return function(peer, cmd, obj)
+	---@param data string
+	---@return string|boolean|nil result, string? error
+	return function(peer, data)
 		local fd = peer.fd
 		if not fd then
-			local err
-			fd, err = connect(peer)
-			if not fd then
-				return nil, err
-			end
-		end
-		local cmdn, dat = marshal("request", cmd, obj)
-		if not cmdn then
-			return nil, dat
+			return nil, "Peer closed"
 		end
 		local traceid = trace_propagate()
-		local session, body = c.request(ctx, cmdn, traceid, dat)
+		local session, body = c.request(ctx, traceid, data)
 		if not session then
 			return nil, body
 		end
@@ -301,7 +247,7 @@ local function callx(is_send)
 		if is_send then
 			return true, nil
 		end
-		return waitfor(session, cmd)
+		return waitfor(session)
 	end
 end
 
@@ -309,19 +255,15 @@ M.call = callx(false)
 M.send = callx(true)
 
 ---@param conf {
----	timeout: integer, -- default 5000 ms
+---	timeout: integer?, -- default 5000 ms
 ---	hardlimit: integer?, -- max body size before error (default 128MB)
 ---	softlimit: integer?, -- max body size before warning (default 65535)
----	marshal: silly.net.cluster.marshal,
----	unmarshal: silly.net.cluster.unmarshal,
 ---	call: silly.net.cluster.call,
 ---	accept: silly.net.cluster.accept?,
 ---	close:  silly.net.cluster.close?,
 ---}
 function M.serve(conf)
 	expire = conf.timeout or 5000
-	marshal = assert(conf.marshal)
-	unmarshal = assert(conf.unmarshal)
 	call = assert(conf.call)
 	accept = conf.accept
 	close = conf.close

--- a/lualib/types/silly/net/cluster/c.lua
+++ b/lualib/types/silly/net/cluster/c.lua
@@ -16,8 +16,7 @@ function M.create(hardlimit, softlimit) end
 ---@return integer fd
 ---@return string  dat
 ---@return integer session
----@return integer? cmd
----@return integer traceid
+---@return integer? traceid --nil for rpc responses
 function M.pop(cluster) end
 
 ---Push a message to cluster
@@ -31,12 +30,11 @@ function M.push(cluster, fd, ptr, size) end
 
 ---Send a request to cluster
 ---@param cluster silly.net.cluster.context
----@param cmd integer
 ---@param traceid integer
 ---@param data string|lightuserdata
 ---@param size? integer
 ---@return integer|false session_id, string body_or_error
-function M.request(cluster, cmd, traceid, data, size) end
+function M.request(cluster, traceid, data, size) end
 
 ---Send a response to cluster
 ---@param cluster silly.net.cluster.context

--- a/test/testcluster.lua
+++ b/test/testcluster.lua
@@ -1,12 +1,13 @@
 local silly = require "silly"
+local task = require "silly.task"
 local time = require "silly.time"
 local np = require "silly.net.cluster.c"
+local channel = require "silly.sync.channel"
 local waitgroup = require "silly.sync.waitgroup"
 local cluster = require "silly.net.cluster"
 local crypto = require "silly.crypto.utils"
 local errno = require "silly.errno"
 local testaux = require "test.testaux"
-local zproto = require "zproto"
 
 -- NOTE (test-only use of silly.errno):
 -- ETIMEDOUT is used here to white-box test that silly.net.cluster
@@ -43,7 +44,7 @@ local function buildpacket()
 	local len = math.random(1, 30)
 	local raw = testaux.randomdata(len)
 	testaux.asserteq(#raw, len, "random packet length")
-	local hdr = string.pack("<I4I4I8", 0, 0, 0) --session, cmd, traceid
+	local hdr = string.pack("<I8I8", 0, 0) --session(8), traceid(8)
 	local body = hdr .. raw
 	local pk = string.pack("<I4", #body) .. body
 	return raw, pk
@@ -189,7 +190,7 @@ testaux.case("Test 9: Hardlimit push (error)", function()
 	local limit = 64
 	local buf = np.create(limit, limit)
 	local body = string.rep("x", limit + 1)
-	local hdr = string.pack("<I4I4I8", 0, 0, 0) --session, cmd, traceid
+	local hdr = string.pack("<I8I8", 0, 0) --session(8), traceid(8)
 	body = hdr .. body
 	local pk = string.pack("<I4", #body) .. body
 	local ptr, size = testaux.new(pk)
@@ -202,23 +203,54 @@ testaux.case("Test 10: Hardlimit push (ok)", function()
 	local limit = 256
 	local buf = np.create(limit, limit)
 	local raw = "hello"
-	local hdr = string.pack("<I4I4I8", 0, 0, 0) --session, cmd, traceid
+	local expected_session = 0x100000001
+	local expected_traceid = 42
+	-- Wire request body header: session(8), traceid(8).
+	local hdr = string.pack("<I8I8", expected_session,
+		expected_traceid)
 	local body = hdr .. raw
 	local pk = string.pack("<I4", #body) .. body
 	local ptr, size = testaux.new(pk)
 	local ok, err = np.push(buf, 1, ptr, size)
 	testaux.asserteq(ok, true, "hardlimit push within limit should succeed")
 	testaux.asserteq(err, nil, "hardlimit push within limit should have no error")
-	local fd, data = np.pop(buf)
+	local fd, data, session, traceid, isreq = np.pop(buf)
 	testaux.asserteq(fd, 1, "hardlimit push within limit fd")
 	testaux.asserteq(data, raw, "hardlimit push within limit data")
+	testaux.asserteq(session, expected_session,
+		"Test 10.1: Request session should be decoded")
+	testaux.asserteq(traceid, expected_traceid,
+		"Test 10.2: Request traceid should be decoded")
+	testaux.asserteq(isreq, nil,
+		"Test 10.3: Pop should return four values")
+
+	local response = np.response(buf, session, "response")
+	local response_ptr, response_size = testaux.new(response)
+	local response_ok, response_err = np.push(buf, 2,
+		response_ptr, response_size)
+	testaux.asserteq(response_ok, true,
+		"Test 10.4: Response packet should be accepted")
+	testaux.asserteq(response_err, nil,
+		"Test 10.5: Response packet should not return an error")
+	local response_fd, response_data, response_session,
+		response_traceid, response_isreq = np.pop(buf)
+	testaux.asserteq(response_fd, 2,
+		"Test 10.6: Response fd should be decoded")
+	testaux.asserteq(response_data, "response",
+		"Test 10.7: Response data should be decoded")
+	testaux.asserteq(response_session, session,
+		"Test 10.8: Response session should be decoded")
+	testaux.asserteq(response_traceid, nil,
+		"Test 10.9: Response traceid should be nil")
+	testaux.asserteq(response_isreq, nil,
+		"Test 10.10: Pop should not return a request flag")
 end)
 
 testaux.case("Test 11: Hardlimit request (error)", function()
 	local limit = 32
 	local buf = np.create(limit, limit)
 	local data = string.rep("x", limit)
-	local session, err = np.request(buf, 1, 0, data)
+	local session, err = np.request(buf, 0, data)
 	testaux.asserteq(session, false, "hardlimit request should fail")
 	testaux.assertneq(err, nil, "hardlimit request should return error string")
 end)
@@ -233,74 +265,22 @@ testaux.case("Test 12: Hardlimit response (error)", function()
 end)
 
 
-local logic = zproto:parse [[
-foo 0xff {
-	.name:string 1
-	.age:integer 2
-	.rand:string 3
-}
-bar 0xfe {
-	.rand:string 1
-}
-]]
-
-print(type(logic))
-assert(logic)
-
-local function case_one(peer, cmd, msg)
-	return msg
+local function case_one(peer, data)
+	return data
 end
 
-local function case_two(peer, cmd, msg)
+local function case_two(peer, data)
 	time.sleep(100)
-	return msg
+	return data
 end
 
-local function case_three(peer, cmd, msg)
+local function case_three(peer, data)
 	time.sleep(2000)
 end
 
-local function case_four(peer, cmd, msg)
+local function case_four(peer, data)
 	local big = string.rep("x", CLUSTER_HARDLIMIT + 1024)
-	return {
-		name = msg.name,
-		age = msg.age,
-		rand = big,
-	}
-end
-
-local callret = {
-	["foo"] = "bar",
-	[0xff] = "bar",
-	["bar"] = "foo",
-	[0xfe] = "foo",
-}
-
-local function unmarshal(typ, cmd, buf, size)
-	if typ == "response" then
-		cmd = callret[cmd]
-	end
-	local dat, size = logic:unpack(buf, size, true)
-	local body = logic:decode(cmd, dat, size)
-	return body
-end
-
-local function marshal(typ, cmd, body)
-	if typ == "response" then
-		if not body then
-			return nil, nil
-		end
-		cmd = callret[cmd]
-		if not cmd then --no need response
-			return nil, nil
-		end
-	end
-	if type(cmd) == "string" then
-		cmd = logic:tag(cmd)
-	end
-	local dat, sz = logic:encode(cmd, body, true)
-	local buf = logic:pack(dat, sz, false)
-	return cmd, buf
+	return big
 end
 
 local case = case_one
@@ -313,43 +293,33 @@ cluster.serve {
 	timeout = CLUSTER_TIMEOUT,
 	hardlimit = CLUSTER_HARDLIMIT,
 	softlimit = CLUSTER_SOFTLIMIT,
-	marshal = marshal,
-	unmarshal = unmarshal,
 	accept = function(peer)
 		accept_peer = peer
 		accept_addr = peer.remoteaddr
 	end,
-	call = function(peer, cmd, msg)
-		return case(peer, cmd, msg)
+	call = function(peer, data)
+		return case(peer, data)
 	end,
 	close = function(peer, errno)
 	end,
 }
 
-local function request(fd, index, count, cmd)
+local function request(fd, index, count)
 	return function()
 		for i = 1, count do
-			local test = {
-				name = "hello",
-				age = index,
-				rand = crypto.randomkey(8),
-			}
-			local body, err = cluster.call(fd, cmd, test)
+			local data = "hello-" .. index .. "-" .. crypto.randomkey(8)
+			local body, err = cluster.call(fd, data)
 			testaux.assertneq(body, nil, err)
-			testaux.asserteq(test.rand, body and body.rand, "rpc match request/response")
+			testaux.asserteq(data, body, "rpc match request/response")
 		end
 	end
 end
 
-local function timeout(fd, index, count, cmd)
+local function timeout(fd, index, count)
 	return function()
 		for i = 1, count do
-			local test = {
-				name = "hello",
-				age = index,
-				rand = crypto.randomkey(8),
-			}
-			local body, err = cluster.call(fd, cmd, test)
+			local data = "hello-" .. index
+			local body, err = cluster.call(fd, data)
 			testaux.asserteq(body, nil, err)
 			testaux.asserteq(err, ETIMEDOUT, "rpc timeout, ack is timeout")
 		end
@@ -361,33 +331,27 @@ testaux.case("Test 13: Cluster listen/connect", function()
 	accept_addr = nil
 	listener = cluster.listen("127.0.0.1:8989")
 	testaux.assertneq(listener, nil, "listener should start")
-	client_peer = cluster.connect("127.0.0.1:8989")
-	testaux.assertneq(client_peer, nil, "client connect should succeed")
-	testaux.asserteq(client_peer.fd, nil, "fd should be nil before first call (lazy connect)")
-	testaux.asserteq(client_peer.addr, "127.0.0.1:8989", "peer should have addr")
+	local err
+	client_peer, err = cluster.connect("127.0.0.1:8989")
+	testaux.assertneq(client_peer, nil, "connect should succeed: " .. tostring(err))
+	testaux.assertneq(client_peer.fd, nil, "fd should be set (eager connect)")
 	testaux.asserteq(client_peer.remoteaddr, "127.0.0.1:8989", "peer should have remoteaddr")
-	-- Trigger lazy connect so accept callback fires on the server side.
-	case = case_one
-	local ack = cluster.call(client_peer, "foo", { name = "x", age = 1, rand = "z" })
-	testaux.assertneq(ack, nil, "first call should establish connection")
-	testaux.assertneq(client_peer.fd, nil, "fd should be set after first call")
 	wait_done(function()
 		return accept_peer ~= nil
 	end, 2000, "accept")
 	testaux.assertneq(accept_addr, nil, "accept addr should be set")
+	-- Verify RPC works
+	case = case_one
+	local ack = cluster.call(client_peer, "test-data")
+	testaux.assertneq(ack, nil, "call should succeed")
+	testaux.asserteq(ack, "test-data", "call should echo")
 end)
 
 testaux.case("Test 14: RPC case one", function()
 	local wg = waitgroup.new()
 	case = case_one
 	for i = 1, 2 do
-		local cmd
-		if i % 2 == 0 then
-			cmd = "foo"
-		else
-			cmd = "bar"
-		end
-		wg:fork(request(client_peer, i, 5, cmd))
+		wg:fork(request(client_peer, i, 5))
 	end
 	wg:wait()
 end)
@@ -396,7 +360,7 @@ testaux.case("Test 15: RPC case two (delay)", function()
 	local wg = waitgroup.new()
 	case = case_two
 	for i = 1, 20 do
-		wg:fork(request(client_peer, i, 50, "foo"))
+		wg:fork(request(client_peer, i, 50))
 		time.sleep(100)
 	end
 	wg:wait()
@@ -406,22 +370,46 @@ testaux.case("Test 16: RPC case three (timeout)", function()
 	local wg = waitgroup.new()
 	case = case_three
 	for i = 1, 20 do
-		wg:fork(timeout(client_peer, i, 2, "foo"))
+		wg:fork(timeout(client_peer, i, 2))
 		time.sleep(10)
 	end
 	wg:wait()
 end)
 
+testaux.case("Test 18: Late response after timeout", function()
+	local entered = channel.new()
+	local release = channel.new()
+	local completed = channel.new()
+	case = function(peer, data)
+		entered:push(true)
+		release:pop()
+		return data
+	end
+	task.fork(function()
+		local body, err = cluster.call(client_peer, "late-response")
+		completed:push({body, err})
+	end)
+	entered:pop()
+	local result = completed:pop()
+	testaux.asserteq(result[1], nil,
+		"Test 18.1: Delayed call should time out")
+	testaux.asserteq(result[2], ETIMEDOUT,
+		"Test 18.2: Delayed call should return timeout error")
+	case = case_one
+	release:push(true)
+	local body, err = cluster.call(client_peer, "after-late-response")
+	testaux.asserteq(body, "after-late-response",
+		"Test 18.3: Cluster should process calls after a late response")
+	testaux.asserteq(err, nil,
+		"Test 18.4: Call after late response should not fail")
+end)
+
 testaux.case("Test 17: Server callback", function()
 	case = case_one
-	local req = {
-		name = "hello",
-		age = 1,
-		rand = crypto.randomkey(8),
-	}
-	local ack, _ = cluster.call(accept_peer, "foo", req)
-	testaux.assertneq(ack, nil, "rpc timeout")
-	testaux.asserteq(req.rand, ack and ack.rand, "rpc match request/response")
+	local data = "server-callback-" .. crypto.randomkey(8)
+	local ack, _ = cluster.call(accept_peer, data)
+	testaux.assertneq(ack, nil, "rpc should succeed")
+	testaux.asserteq(data, ack, "rpc should echo")
 	local old_fd = accept_peer.fd
 	cluster.close(accept_peer)
 	wait_done(function()
@@ -431,51 +419,27 @@ testaux.case("Test 17: Server callback", function()
 		return client_peer.fd == nil
 	end, 2000, "client close")
 	accept_peer = nil
-
-	local test = {
-		name = "hello",
-		age = 999,
-		rand = crypto.randomkey(8),
-	}
-	local body, err = cluster.call(client_peer, "foo", test)
-	testaux.assertneq(body, nil, "reconnection should succeed: " .. tostring(err))
-	testaux.asserteq(test.rand, body and body.rand, "reconnect call should match request/response")
-
+	-- client_peer connection dropped by server close; reconnect for subsequent tests
+	client_peer = nil
+	local err
+	client_peer, err = cluster.connect("127.0.0.1:8989")
+	testaux.assertneq(client_peer, nil, "reconnect should succeed: " .. tostring(err))
 	wait_done(function()
-		return accept_peer and accept_peer.fd and accept_peer.fd ~= old_fd
-	end, 2000, "accept reconnect")
-
-	local req = {
-		name = "world",
-		age = 888,
-		rand = crypto.randomkey(8),
-	}
-	local ack, _ = cluster.call(accept_peer, "bar", req)
-	testaux.assertneq(ack, nil, "server callback should succeed")
-	testaux.asserteq(req.rand, ack and ack.rand, "server callback should match")
+		return accept_peer ~= nil
+	end, 2000, "reconnect accept")
 end)
 
 testaux.case("Test 19: Cluster call oversize request", function()
 	case = case_one
 	local big = string.rep("x", CLUSTER_HARDLIMIT + 1024)
-	local test = {
-		name = "hello",
-		age = 123,
-		rand = big,
-	}
-	local body, err = cluster.call(client_peer, "foo", test)
+	local body, err = cluster.call(client_peer, big)
 	testaux.asserteq(body, nil, "oversize request should fail")
 	testaux.assertneq(err, nil, "oversize request should return error")
 end)
 
 testaux.case("Test 20: Cluster call oversize response", function()
 	case = case_four
-	local test = {
-		name = "hello",
-		age = 456,
-		rand = crypto.randomkey(8),
-	}
-	local body, err = cluster.call(client_peer, "foo", test)
+	local body, err = cluster.call(client_peer, "trigger-big-response")
 	testaux.asserteq(body, nil, "oversize response should fail")
 	testaux.asserteq(err, ETIMEDOUT, "oversize response should timeout")
 	case = case_one
@@ -483,25 +447,20 @@ end)
 
 testaux.case("Test 21: Multiple connections to same address", function()
 	case = case_one
-	-- Connect two peers to the same listener
-	local p1 = cluster.connect("127.0.0.1:8989")
+	local err1, err2
+	local p1, _ = cluster.connect("127.0.0.1:8989")
 	testaux.assertneq(p1, nil, "p1 connect should succeed")
-	testaux.asserteq(p1.fd, nil, "p1 fd should be nil before first call (lazy connect)")
-	testaux.asserteq(p1.addr, "127.0.0.1:8989", "p1 should have addr")
+	testaux.assertneq(p1.fd, nil, "p1 fd should be set (eager connect)")
 	testaux.asserteq(p1.remoteaddr, "127.0.0.1:8989", "p1 should have remoteaddr")
-	local p2 = cluster.connect("127.0.0.1:8989")
+	local p2, _ = cluster.connect("127.0.0.1:8989")
 	testaux.assertneq(p2, nil, "p2 connect should succeed")
-	testaux.asserteq(p2.fd, nil, "p2 fd should be nil before first call (lazy connect)")
-	-- First call triggers the actual connection for each peer independently
-	local r1, _ = cluster.call(p1, "foo", { name = "a", age = 1, rand = "x" })
+	testaux.assertneq(p2.fd, nil, "p2 fd should be set (eager connect)")
+	local r1, _ = cluster.call(p1, "data-a")
 	testaux.assertneq(r1, nil, "p1 call should succeed")
-	testaux.asserteq(r1.rand, "x", "p1 call should match")
-	testaux.assertneq(p1.fd, nil, "p1 fd should be set after first call")
-	local r2, _ = cluster.call(p2, "bar", { name = "b", age = 2, rand = "y" })
+	testaux.asserteq(r1, "data-a", "p1 call should match")
+	local r2, _ = cluster.call(p2, "data-b")
 	testaux.assertneq(r2, nil, "p2 call should succeed")
-	testaux.asserteq(r2.rand, "y", "p2 call should match")
-	testaux.assertneq(p2.fd, nil, "p2 fd should be set after first call")
-	-- Two connections to same address must hold independent fds
+	testaux.asserteq(r2, "data-b", "p2 call should match")
 	testaux.assertneq(p1.fd, p2.fd, "two peers should have different fds")
 	cluster.close(p1)
 	cluster.close(p2)
@@ -509,63 +468,22 @@ end)
 
 testaux.case("Test 22: Call after active close returns peer closed", function()
 	case = case_one
-	local p = cluster.connect("127.0.0.1:8989")
-	-- Establish the connection so we exercise the active-close path, not
-	-- just the never-connected path.
-	local r, _ = cluster.call(p, "foo", { name = "c", age = 1, rand = "z" })
+	local p, err = cluster.connect("127.0.0.1:8989")
+	testaux.assertneq(p, nil, "connect should succeed: " .. tostring(err))
+	local r, _ = cluster.call(p, "test")
 	testaux.assertneq(r, nil, "first call should succeed")
-	testaux.assertneq(p.fd, nil, "fd should be set after first call")
+	testaux.assertneq(p.fd, nil, "fd should be set after connect")
 	cluster.close(p)
 	testaux.asserteq(p.fd, nil, "fd should be cleared after close")
-	testaux.asserteq(p.addr, nil, "addr should be cleared after close")
-	local r2, err = cluster.call(p, "foo", { name = "c", age = 1, rand = "z" })
+	local r2, err2 = cluster.call(p, "test")
 	testaux.asserteq(r2, nil, "call after close should fail")
-	testaux.asserteq(err, "Peer closed", "call after close should return peer closed")
-	-- Never-connected peer: close immediately, then call.
-	local q = cluster.connect("127.0.0.1:8989")
-	cluster.close(q)
-	local r3, err2 = cluster.call(q, "foo", { name = "c", age = 1, rand = "z" })
-	testaux.asserteq(r3, nil, "call on never-connected closed peer should fail")
-	testaux.asserteq(err2, "Peer closed", "call on never-connected closed peer should return peer closed")
+	testaux.asserteq(err2, "Peer closed", "call after close should return peer closed")
 end)
 
-testaux.case("Test 23: Close during in-flight connect", function()
-	case = case_one
-	accept_peer = nil
-	local p = cluster.connect("127.0.0.1:8989")
-	-- Task A calls on a peer with fd == nil, so it yields inside
-	-- net.tcpconnect waiting for the CONNECT event. Task B is scheduled
-	-- while A is yielded and clears peer.addr. When A resumes, its
-	-- in-flight fd must be discarded and the call must surface
-	-- "peer closed" rather than returning a live connection on a peer
-	-- the user already closed.
-	local wg = waitgroup.new()
-	local call_result, call_err
-	wg:fork(function()
-		call_result, call_err = cluster.call(p, "foo",
-			{ name = "r", age = 1, rand = "z" })
-	end)
-	wg:fork(function()
-		cluster.close(p)
-	end)
-	wg:wait()
-	testaux.asserteq(call_result, nil,
-		"concurrent close must abort the in-flight call")
-	testaux.asserteq(call_err, "Peer closed",
-		"concurrent close must surface peer closed")
-	testaux.asserteq(p.fd, nil,
-		"peer.fd must remain nil after concurrent close")
-	testaux.asserteq(p.addr, nil,
-		"peer.addr must remain cleared after concurrent close")
-	-- The race closes the client-side fd after the server has already
-	-- accepted it. Wait for the server-side accept to fire and then for
-	-- its peer fd to be cleaned up before the netstat check runs.
-	wait_done(function()
-		return accept_peer ~= nil
-	end, 2000, "server accept after race")
-	wait_done(function()
-		return accept_peer.fd == nil
-	end, 2000, "server cleanup after race")
+testaux.case("Test 23: Connect to non-listening port fails", function()
+	local p, err = cluster.connect("127.0.0.1:19999")
+	testaux.asserteq(p, nil, "connect should fail to non-listening port")
+	testaux.assertneq(err, nil, "should return error string")
 end)
 
 testaux.case("Test 24: Cluster cleanup", function()
@@ -574,26 +492,19 @@ testaux.case("Test 24: Cluster cleanup", function()
 	cluster.close(listener)
 end)
 
-testaux.case("Test 25: Cluster DNS failure returns host-specific string", function()
+testaux.case("Test 25: Cluster connect DNS failure returns host-specific string", function()
 	testaux.with_mocked_dns(function(host, qtype)
 		return nil, "Query timed out (10001)"
 	end, {"silly.net.cluster"}, function(reloaded)
 		local mock_cluster = reloaded["silly.net.cluster"]
 		mock_cluster.serve {
 			timeout = 1000,
-			marshal = function(kind, cmd, obj)
-				return 1, ""
-			end,
-			unmarshal = function(kind, cmd, body)
-				return {}, nil
-			end,
-			call = function(fd, cmd, obj)
-				return {}
+			call = function(peer, data)
+				return data
 			end,
 		}
-		local peer = mock_cluster.connect("dns-fail.test:8989")
-		local resp, err = mock_cluster.call(peer, "foo", {})
-		testaux.asserteq(resp, nil, "Test 25.1: Cluster call should fail on DNS error")
+		local peer, err = mock_cluster.connect("dns-fail.test:8989")
+		testaux.asserteq(peer, nil, "Test 25.1: connect should fail on DNS error")
 		testaux.assertcontains(err, "dns lookup",
 			"Test 25.2: Error should mention dns lookup")
 		testaux.assertcontains(err, "dns-fail.test",


### PR DESCRIPTION
Peer-to-peer connections usually need application-level arbitration, so reconnect policy belongs to the application. Peers may also use different wire protocols. Some protocols carry a command in both requests and responses, while others only carry it in the request. Once marshaling moved out of cluster, cmd was no longer meaningful there either. Keeping both outside lets each link define its own protocol and leaves cluster as a raw-string transport.